### PR TITLE
Update Sign Command Documentation

### DIFF
--- a/src/pages/candy-machine/sugar/commands/sign.md
+++ b/src/pages/candy-machine/sugar/commands/sign.md
@@ -17,3 +17,13 @@ And running with a specific keypair:
 ```
 sugar sign -k creator-keypair.json
 ```
+
+Note using `sugar sign` relies on a standard `getProgramAccounts` call to the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). Ensure that the RPC node you use supports standard gPA calls to that address, as it can be pretty intensive. Developers can provide a custom RPC URL with the command:
+```
+sugar sign -r <RPC_URL>
+```
+
+Alternatively, NFTs can be signed one at a time using the command:
+```
+sugar sign -m <MINT_ADDRESS>
+```

--- a/src/pages/candy-machine/sugar/commands/sign.md
+++ b/src/pages/candy-machine/sugar/commands/sign.md
@@ -22,7 +22,7 @@ Developers can provide a custom RPC URL with the command:
 ```
 sugar sign -r <RPC_URL>
 ```
-Note using `sugar sign` relies on an inefficient `getProgramAccounts` call to the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). The recommended solution is to sign NFTs individually using the command:
+Note using `sugar sign` relies on an inefficient `getProgramAccounts` call on the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). The recommended solution is to sign NFTs individually using the command:
 ```
 sugar sign -m <MINT_ADDRESS>
 ```

--- a/src/pages/candy-machine/sugar/commands/sign.md
+++ b/src/pages/candy-machine/sugar/commands/sign.md
@@ -22,7 +22,7 @@ Developers can provide a custom RPC URL with the command:
 ```
 sugar sign -r <RPC_URL>
 ```
-Note using `sugar sign` relies on a standard `getProgramAccounts` call to the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). This is very inefficient. The recommended solution is to sign NFTs individually using the command:
+Note using `sugar sign` relies on an inefficient `getProgramAccounts` call to the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). The recommended solution is to sign NFTs individually using the command:
 ```
 sugar sign -m <MINT_ADDRESS>
 ```

--- a/src/pages/candy-machine/sugar/commands/sign.md
+++ b/src/pages/candy-machine/sugar/commands/sign.md
@@ -18,12 +18,11 @@ And running with a specific keypair:
 sugar sign -k creator-keypair.json
 ```
 
-Note using `sugar sign` relies on a standard `getProgramAccounts` call to the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). Ensure that the RPC node you use supports standard gPA calls to that address, as it can be pretty intensive. Developers can provide a custom RPC URL with the command:
+Developers can provide a custom RPC URL with the command:
 ```
 sugar sign -r <RPC_URL>
 ```
-
-Alternatively, NFTs can be signed one at a time using the command:
+Note using `sugar sign` relies on a standard `getProgramAccounts` call to the Metaplex Token Metadata program (i.e., `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`). This is very inefficient. The recommended solution is to sign NFTs individually using the command:
 ```
 sugar sign -m <MINT_ADDRESS>
 ```


### PR DESCRIPTION
This PR aims to update Sugar's `sign` command documentation. The updated documentation makes users aware that the command relies on a standard gPA call to Metaplex's Token Program (pursuant to [PR #389](https://github.com/metaplex-foundation/sugar/pull/389)). The update emphasizes that such calls can be resource-intensive and might be blocked by some RPC providers