### PR TITLE
Point JSON Link to developer hub instead of docs.metaplex.com

### DIFF
--- a/src/pages/candy-machine/index.md
+++ b/src/pages/candy-machine/index.md
@@ -76,7 +76,7 @@ However, we still don’t know which NFTs should be minted from that Candy Machi
 Each item is composed of two parameters:
 
 - A `name`: The name of the NFT.
-- A `uri`: The URI pointing to the [JSON metadata](https://docs.metaplex.com/programs/token-metadata/overview#a-json-standard) of the NFT. This implies that the JSON metadata has already been uploaded via either an on-chain (e.g. Arweave, IPFS) or off-chain (e.g. AWS, your own server) storage provider.
+- A `uri`: The URI pointing to the [JSON metadata](https://developers.metaplex.com/token-metadata/token-standard#the-non-fungible-standard) of the NFT. This implies that the JSON metadata has already been uploaded via either an on-chain (e.g. Arweave, IPFS) or off-chain (e.g. AWS, your own server) storage provider.
 
 All other parameters are shared between all NFTs and are therefore kept in the settings of the Candy Machine directly to avoid repetition. See [Inserting Items](/candy-machine/insert-items) for more details.
 


### PR DESCRIPTION
The old link points to the old docs.