### PR TITLE
fix nftStorage snippet

### DIFF
--- a/src/pages/candy-machine/insert-items.md
+++ b/src/pages/candy-machine/insert-items.md
@@ -28,7 +28,7 @@ Umi ships with an `uploader` interface that can be used to upload JSON data to t
 
 ```ts
 import { nftStorage } from '@metaplex-foundation/umi-uploader-nft-storage'
-umi.use(nftStorage())
+umi.use(nftStorageUploader({ token: 'YOUR_API_TOKEN' }))
 ```
 
 You may then use the `upload` and `uploadJson` methods of the `uploader` interface to upload your assets and their JSON metadata.


### PR DESCRIPTION
The function is not called `nftStorage()` but `nftStorageUploader()`. It also requires a API token.

This change aligns it to the token metadata mint page.