### PR TITLE
Minor improvement to leaf/asset ID example

### DIFF
--- a/src/pages/bubblegum/index.md
+++ b/src/pages/bubblegum/index.md
@@ -124,7 +124,7 @@ Even though NFT data does not live inside accounts, it is still possible to exec
 
 - [Mint a cNFT](/bubblegum/mint-cnfts) with or without an associated collection.
 - [Transfer a cNFT](/bubblegum/transfer-cnfts).
-- [Update the data of a cNFT](/bubblegum/update-cnfts) _(Coming Soon)_.
+- [Update the data of a cNFT](/bubblegum/update-cnfts).
 - [Burn a cNFT](/bubblegum/burn-cnfts).
 - [Decompress a cNFT into a regular NFT](/bubblegum/decompress-cnfts). Note that this enables interoperability with existing smart contracts but creates on-chain accounts with rent fees.
 - [Delegate a cNFT](/bubblegum/delegate-cnfts).

--- a/src/pages/bubblegum/mint-cnfts.md
+++ b/src/pages/bubblegum/mint-cnfts.md
@@ -56,8 +56,8 @@ You can retrieve the leaf and determine the asset ID from the `mintV1` transacti
 import { parseLeafFromMintV1Transaction } from '../src';
 
 const { signature } = await mintV1(umi, { leafOwner, merkleTree, metadata }).sendAndConfirm(umi, { confirm: { commitment: 'confirmed' } });
-const leaf = await parseLeafFromMintV1Transaction(umi, signature);
-const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: nonce });
+const leaf: LeafSchema = await parseLeafFromMintV1Transaction(umi, signature);
+const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: leaf.nonce });
 ```
 
 {% /dialect %}
@@ -157,8 +157,8 @@ const { signature } = await mintToCollectionV1(umi, {
   collectionMint: collectionMint.publicKey,
 }).sendAndConfirm(umi);
 
-const leaf = await parseLeafFromMintToCollectionV1Transaction(umi, signature);
-const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: nonce });
+const leaf: LeafSchema = await parseLeafFromMintToCollectionV1Transaction(umi, signature);
+const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: leaf.nonce });
 ```
 
 {% /dialect %}

--- a/src/pages/bubblegum/mint-cnfts.md
+++ b/src/pages/bubblegum/mint-cnfts.md
@@ -47,6 +47,8 @@ await mintV1(umi, {
 {% /dialect %}
 {% /dialect-switcher %}
 
+### Get leaf ID and asset ID from mint transaction
+
 You can retrieve the leaf and determine the asset ID from the `mintV1` transaction using the `parseLeafFromMintV1Transaction` helper.
 
 {% dialect-switcher title="Get leaf ID and asset ID from mint transaction" %}
@@ -141,6 +143,8 @@ await createNft(umi, {
 {% /totem %}
 {% /dialect %}
 {% /dialect-switcher %}
+
+### Get leaf ID and asset ID from mint to collection transaction
 
 Again you can retrieve the leaf and determine the asset ID from the `mintToCollectionV1` transaction using the `parseLeafFromMintToCollectionV1Transaction` helper.
 

--- a/src/pages/bubblegum/mint-cnfts.md
+++ b/src/pages/bubblegum/mint-cnfts.md
@@ -47,11 +47,11 @@ await mintV1(umi, {
 {% /dialect %}
 {% /dialect-switcher %}
 
-### Get leaf ID and asset ID from mint transaction
+### Get leaf schema from mint transaction {% #get-leaf-schema-from-mint-transaction %}
 
 You can retrieve the leaf and determine the asset ID from the `mintV1` transaction using the `parseLeafFromMintV1Transaction` helper.
 
-{% dialect-switcher title="Get leaf ID and asset ID from mint transaction" %}
+{% dialect-switcher title="Get leaf schema from mint transaction" %}
 {% dialect title="JavaScript" id="js" %}
 
 ```ts
@@ -144,11 +144,11 @@ await createNft(umi, {
 {% /dialect %}
 {% /dialect-switcher %}
 
-### Get leaf ID and asset ID from mint to collection transaction
+### Get leaf schema from mint to collection transaction {% #get-leaf-schema-from-mint-to-collection-transaction %}
 
 Again you can retrieve the leaf and determine the asset ID from the `mintToCollectionV1` transaction using the `parseLeafFromMintToCollectionV1Transaction` helper.
 
-{% dialect-switcher title="Get leaf ID and asset ID from mint to collection transaction" %}
+{% dialect-switcher title="Get leaf schema from mint to collection transaction" %}
 {% dialect title="JavaScript" id="js" %}
 
 ```ts


### PR DESCRIPTION
This just makes it clear what you get back from the parse functions and that you can get the nonce out of the leaf schema.

https://developer-hub-git-danenbm-leaf-from-c622d0-metaplex-foundation.vercel.app/bubblegum/mint-cnfts