### PR TITLE
Clarification for tokenStandard enum

### DIFF
--- a/src/pages/token-metadata/token-standard.md
+++ b/src/pages/token-metadata/token-standard.md
@@ -18,11 +18,11 @@ This solves a pain point for third parties such as wallets which, before this fi
 
 The Token Standard field can have the following values:
 
-- `NonFungible`: A non-fungible token with a Master Edition.
-- `FungibleAsset`: A token with metadata that can also have attributes, sometimes called Semi-Fungible.
-- `Fungible`: A token with simple metadata.
-- `NonFungibleEdition`: A non-fungible token with an Edition account (printed from a Master edition).
-- `ProgrammableNonFungible`: A special `NonFungible` token that is frozen at all times to enforce custom authorization rules.
+- `0` / `NonFungible`: A non-fungible token with a Master Edition.
+- `1` / `FungibleAsset` (1): A token with metadata that can also have attributes, sometimes called Semi-Fungible.
+- `2` / `Fungible` (2): A token with simple metadata.
+- `3 / `NonFungibleEdition` (3): A non-fungible token with an Edition account (printed from a Master edition).
+- `4` / `ProgrammableNonFungible` (4): A special `NonFungible` token that is frozen at all times to enforce custom authorization rules.
 
 It is important to note that the Token Standard is set automatically by the Token Metadata program and cannot be manually updated. It uses the following logic to apply the correct standard:
 


### PR DESCRIPTION
Explorers only show the numbers of the token enum, not the values like `NonFungible`.
Since our docs did not show the translation it is quite confusing for some users.