### PR TITLE
Add sugar link in Dev Tools

### DIFF
--- a/src/components/products/index.js
+++ b/src/components/products/index.js
@@ -11,6 +11,7 @@ import { umi } from './umi'
 import { amman } from './amman'
 import { das } from './das-api'
 import { legacyDocumentation } from './legacyDocumentation'
+import { sugar } from './sugar'
 
 
 export const products = [
@@ -26,5 +27,6 @@ export const products = [
   umi,
   amman,
   das,
-  legacyDocumentation
+  legacyDocumentation,
+  sugar
 ].sort((a, b) => a.name.localeCompare(b.name))

--- a/src/components/products/sugar/Hero.jsx
+++ b/src/components/products/sugar/Hero.jsx
@@ -1,0 +1,19 @@
+import { Hero as BaseHero } from '@/components/Hero'
+import { HeroScreenshot } from '@/components/HeroScreenshot'
+
+export function Hero({ page }) {
+  return (
+    <BaseHero
+      page={page}
+      subDescription="Read our documentation to create your own applications or use our Creator Studio to launch your collection in minutes."
+      primaryCta={{ title: 'Sign Up for Creator Studio', href: 'https://studio.metaplex.com/' }}
+    >
+      <HeroScreenshot 
+        src="/assets/candy-machine/creator-studio.png"
+        alt="A screenshot of a mint page in the Creator Studio web app"
+        width={1392}
+        height={860}
+      />
+    </BaseHero>
+  )
+}

--- a/src/components/products/sugar/Logo.jsx
+++ b/src/components/products/sugar/Logo.jsx
@@ -1,0 +1,36 @@
+import { useId } from 'react'
+
+export function Logo(props) {
+  const id = useId()
+
+  return (
+    <svg
+      width="112"
+      height="112"
+      viewBox="0 0 112 112"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M112 10C112 4.47715 107.523 0 102 0H10C4.47715 0 0 4.47715 0 10V52C0 57.5228 4.47715 62 10 62H14.5C18.6421 62 22 65.3579 22 69.5V69.5C22 73.6421 18.6421 77 14.5 77H10C4.47715 77 0 81.4772 0 87V102C0 107.523 4.47715 112 10 112H21.2133C23.8655 112 26.409 110.946 28.2844 109.071L49.2844 88.0711C53.1896 84.1658 59.5213 84.1658 63.4265 88.0711L84.4265 109.071C86.3019 110.946 88.8454 112 91.4976 112H102C107.523 112 112 107.523 112 102V87C112 81.4772 107.523 77 102 77H97.5C93.3579 77 90 73.6421 90 69.5V69.5C90 65.3579 93.3579 62 97.5 62H102C107.523 62 112 57.5228 112 52V10Z"
+        fill={`url(#${id}-gradient)`}
+      />
+      <defs>
+        <linearGradient
+          id={`${id}-gradient`}
+          x1="56"
+          y1="0"
+          x2="56"
+          y2="112"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#7DEDFC" />
+          <stop offset="1" stopColor="#0EA5E9" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}

--- a/src/components/products/sugar/index.js
+++ b/src/components/products/sugar/index.js
@@ -1,0 +1,22 @@
+import {
+  changelogSection,
+  documentationSection,
+  recipesSection,
+  referencesSection,
+} from '@/shared/sections'
+import { Hero } from './Hero'
+import { Logo } from './Logo'
+
+export const sugar = {
+  name: 'Sugar',
+  headline: 'Create Candy Machines easily',
+  description: 'Create Candy Machines easily',
+  navigationMenuCatergory: 'Dev Tools',
+  path: '/candy-machine/sugar',
+  logo: Logo,
+  github: 'https://github.com/metaplex-foundation/sugar',
+  className: 'accent-sky',
+  heroes: [{ path: '/candy-machine/sugar', component: Hero }],
+  sections: [
+  ],
+}


### PR DESCRIPTION
This adds a link in the dev tools menu section for sugar.
It points to the existing sugar docs, but should make them more visible.

![image](https://github.com/metaplex-foundation/developer-hub/assets/93528482/c8238d57-08b3-451f-ade9-fcc2ea40f8dd)
