### PR TITLE
Add decimal example on mint

### DIFF
--- a/src/pages/token-metadata/mint.md
+++ b/src/pages/token-metadata/mint.md
@@ -380,7 +380,7 @@ await createNft(umi, {
 {% totem-accordion title="Create a Fungible" %}
 
 ```ts
-import { percentAmount, generateSigner } from '@metaplex-foundation/umi'
+import { percentAmount, generateSigner, some } from '@metaplex-foundation/umi'
 import { createFungible } from '@metaplex-foundation/mpl-token-metadata'
 
 const mint = generateSigner(umi)
@@ -398,7 +398,7 @@ await createFungible(umi, {
 {% totem-accordion title="Create a FungibleAsset" %}
 
 ```ts
-import { percentAmount, generateSigner } from '@metaplex-foundation/umi'
+import { percentAmount, generateSigner, some } from '@metaplex-foundation/umi'
 import { createFungibleAsset } from '@metaplex-foundation/mpl-token-metadata'
 
 const mint = generateSigner(umi)

--- a/src/pages/token-metadata/mint.md
+++ b/src/pages/token-metadata/mint.md
@@ -385,6 +385,7 @@ await createFungible(umi, {
   name: 'My Fungible',
   uri: 'https://example.com/my-fungible.json',
   sellerFeeBasisPoints: percentAmount(5.5),
+  decimals: some(7), // for 0 decimals use some(0)
 }).sendAndConfirm(umi)
 ```
 
@@ -402,6 +403,7 @@ await createFungibleAsset(umi, {
   name: 'My Fungible Asset',
   uri: 'https://example.com/my-fungible-asset.json',
   sellerFeeBasisPoints: percentAmount(5.5),
+  decimals: some(7) // for 0 decimals use some(0)
 }).sendAndConfirm(umi)
 ```
 

--- a/src/pages/token-metadata/mint.md
+++ b/src/pages/token-metadata/mint.md
@@ -54,6 +54,10 @@ umi.use(nftStorageUploader({ token: 'YOUR_API_TOKEN' }))
 
 Now that we have our **URI**, we can move on to the next step.
 
+{% callout %}
+The next steps show how to create accounts and mint the tokens in two steps. At the [bottom of the page](#create-helpers) there are **code examples** for helpers that combine those steps and make creating different token types easier.
+{% /callout %}
+
 ## Creating accounts
 
 To create all the on-chain accounts required by the Token Standard of your choice, you may simply use the **Create V1** instruction. It will adapt to the requested Token Standard and create the right accounts accordingly.


### PR DESCRIPTION
Some users got confused on how to change the decimals. Especially for decimals 0 you have to use some. Otherwise the JS validation fails internally and it uses 9 instead because of this:
![grafik](https://github.com/metaplex-foundation/developer-hub/assets/93528482/e4af6ad0-5e1f-48e8-8bea-c58945162b59)
