### PR TITLE
fix 404 page 

### DIFF
--- a/src/pages/404.md
+++ b/src/pages/404.md
@@ -8,4 +8,4 @@ We couldn't find this page in the Metaplex Developer Hub.
 
 Select a product below to get started.
 
-{% product-grid /%}
+{% all-product-grid /%}


### PR DESCRIPTION
use all-product-grid instead of product-grid
Fixes the 404 page to look like
![grafik](https://github.com/metaplex-foundation/developer-hub/assets/93528482/0a207357-eab8-4a91-8118-4ba7f07cff14)

instead of the empty
![grafik](https://github.com/metaplex-foundation/developer-hub/assets/93528482/6cb57505-e2c1-438a-9cd6-7f02417cff08)
