### PR TITLE
Feature/references links

### DIFF
--- a/src/components/products/Sections.jsx
+++ b/src/components/products/Sections.jsx
@@ -17,6 +17,7 @@ export function Sections({ sections, activeSectionId, className, props }) {
               ? 'font-medium text-slate-800 dark:text-white'
               : 'text-slate-500 dark:text-slate-400'
           )}
+          target={section.target}
         >
           <Icon
             icon={section.icon}

--- a/src/components/products/bubblegum/index.js
+++ b/src/components/products/bubblegum/index.js
@@ -78,7 +78,11 @@ export const bubblegum = {
         },
       ],
     },
-    { ...referencesSection('bubblegum') },
+    {
+      ...referencesSection('bubblegum'),
+      href: 'https://mpl-bubblegum-js-docs.vercel.app/',
+      target: '_blank'
+    },
     { ...recipesSection('bubblegum') },
     { ...changelogSection('bubblegum') },
   ],

--- a/src/components/products/candyMachine/index.js
+++ b/src/components/products/candyMachine/index.js
@@ -54,34 +54,64 @@ export const candyMachine = {
         {
           title: 'Available Guards',
           links: [
-            { title: 'Address Gate', href: '/candy-machine/guards/address-gate' },
+            {
+              title: 'Address Gate',
+              href: '/candy-machine/guards/address-gate',
+            },
             { title: 'Allocation', href: '/candy-machine/guards/allocation' },
             { title: 'Allow List', href: '/candy-machine/guards/allow-list' },
             { title: 'Bot Tax', href: '/candy-machine/guards/bot-tax' },
             { title: 'End Date', href: '/candy-machine/guards/end-date' },
-            { title: 'Freeze Sol Payment', href: '/candy-machine/guards/freeze-sol-payment' },
-            { title: 'Freeze Token Payment', href: '/candy-machine/guards/freeze-token-payment' },
+            {
+              title: 'Freeze Sol Payment',
+              href: '/candy-machine/guards/freeze-sol-payment',
+            },
+            {
+              title: 'Freeze Token Payment',
+              href: '/candy-machine/guards/freeze-token-payment',
+            },
             { title: 'Gatekeeper', href: '/candy-machine/guards/gatekeeper' },
             { title: 'Mint Limit', href: '/candy-machine/guards/mint-limit' },
             { title: 'NFT Burn', href: '/candy-machine/guards/nft-burn' },
             { title: 'NFT Gate', href: '/candy-machine/guards/nft-gate' },
             { title: 'NFT Payment', href: '/candy-machine/guards/nft-payment' },
-            { title: 'Program Gate', href: '/candy-machine/guards/program-gate' },
-            { title: 'Redeemed Amount', href: '/candy-machine/guards/redeemed-amount' },
+            {
+              title: 'Program Gate',
+              href: '/candy-machine/guards/program-gate',
+            },
+            {
+              title: 'Redeemed Amount',
+              href: '/candy-machine/guards/redeemed-amount',
+            },
             { title: 'Sol Payment', href: '/candy-machine/guards/sol-payment' },
             { title: 'Start Date', href: '/candy-machine/guards/start-date' },
-            { title: 'Third Party Signer', href: '/candy-machine/guards/third-party-signer' },
+            {
+              title: 'Third Party Signer',
+              href: '/candy-machine/guards/third-party-signer',
+            },
             { title: 'Token Burn', href: '/candy-machine/guards/token-burn' },
             { title: 'Token Gate', href: '/candy-machine/guards/token-gate' },
-            { title: 'Token Payment', href: '/candy-machine/guards/token-payment' },
-            { title: 'Token2022 Payment', href: '/candy-machine/guards/token2022-payment' },
+            {
+              title: 'Token Payment',
+              href: '/candy-machine/guards/token-payment',
+            },
+            {
+              title: 'Token2022 Payment',
+              href: '/candy-machine/guards/token2022-payment',
+            },
           ],
         },
         {
           title: 'Custom Guards',
           links: [
-            { title: 'Writing a Custom Guard', href: '/candy-machine/custom-guards/writing-custom-guards' },
-            { title: 'Generating Client', href: '/candy-machine/custom-guards/generating-client' },
+            {
+              title: 'Writing a Custom Guard',
+              href: '/candy-machine/custom-guards/writing-custom-guards',
+            },
+            {
+              title: 'Generating Client',
+              href: '/candy-machine/custom-guards/generating-client',
+            },
           ],
         },
       ],
@@ -96,8 +126,14 @@ export const candyMachine = {
           title: 'Introduction',
           links: [
             { title: 'Overview', href: '/candy-machine/sugar' },
-            { title: 'Installation', href: '/candy-machine/sugar/installation' },
-            { title: 'Getting Started', href: '/candy-machine/sugar/getting-started' },
+            {
+              title: 'Installation',
+              href: '/candy-machine/sugar/installation',
+            },
+            {
+              title: 'Getting Started',
+              href: '/candy-machine/sugar/getting-started',
+            },
           ],
         },
         {
@@ -118,7 +154,10 @@ export const candyMachine = {
           links: [
             { title: 'airdrop', href: '/candy-machine/sugar/commands/airdrop' },
             { title: 'bundlr', href: '/candy-machine/sugar/commands/bundlr' },
-            { title: 'collection', href: '/candy-machine/sugar/commands/collection' },
+            {
+              title: 'collection',
+              href: '/candy-machine/sugar/commands/collection',
+            },
             { title: 'config', href: '/candy-machine/sugar/commands/config' },
             { title: 'deploy', href: '/candy-machine/sugar/commands/deploy' },
             { title: 'freeze', href: '/candy-machine/sugar/commands/freeze' },
@@ -131,20 +170,33 @@ export const candyMachine = {
             { title: 'sign', href: '/candy-machine/sugar/commands/sign' },
             { title: 'update', href: '/candy-machine/sugar/commands/update' },
             { title: 'upload', href: '/candy-machine/sugar/commands/upload' },
-            { title: 'validate', href: '/candy-machine/sugar/commands/validate' },
+            {
+              title: 'validate',
+              href: '/candy-machine/sugar/commands/validate',
+            },
             { title: 'verify', href: '/candy-machine/sugar/commands/verify' },
-            { title: 'withdraw', href: '/candy-machine/sugar/commands/withdraw' },
+            {
+              title: 'withdraw',
+              href: '/candy-machine/sugar/commands/withdraw',
+            },
           ],
         },
         {
           title: 'References',
           links: [
-            { title: 'Bring Your Own Uploader', href: '/candy-machine/sugar/bring-your-own-uploader' },
+            {
+              title: 'Bring Your Own Uploader',
+              href: '/candy-machine/sugar/bring-your-own-uploader',
+            },
           ],
         },
       ],
     },
-    { ...referencesSection('candy-machine') },
+    {
+      ...referencesSection('candy-machine'),
+      href: `https://mpl-candy-machine-js-docs.vercel.app/`,
+      target: '_blank',
+    },
     /*
     {
       ...recipesSection('candy-machine'),

--- a/src/components/products/candyMachine4/index.js
+++ b/src/components/products/candyMachine4/index.js
@@ -237,7 +237,11 @@ export const candyMachine4 = {
         },
       ],
     },
-    { ...referencesSection('candy-machine-4') },
+    {
+      ...referencesSection('candy-machine-4'),
+      href: `https://mpl-core-candy-machine-js-docs.vercel.app/`,
+      target: '_blank',
+    },
     /*
     {
       ...recipesSection('candy-machine'),

--- a/src/components/products/core/index.js
+++ b/src/components/products/core/index.js
@@ -106,6 +106,7 @@ export const core = {
     { 
       ...referencesSection('core'),
       href: `https://mpl-core-js-docs.vercel.app/`,
+      target: '_blank'
      },
     // { ...guidesSection('core') },
     // { ...recipesSection('core') },

--- a/src/components/products/das-api/index.js
+++ b/src/components/products/das-api/index.js
@@ -46,6 +46,11 @@ export const das = {
         },
       ],
     },
+    {
+      ...referencesSection('das-api'),
+      href: `https://digital-asset-standard-api-js-docs.vercel.app/`,
+      target: '_blank',
+    },
     { ...changelogSection('das-api') },
   ],
 }

--- a/src/components/products/hydra/index.js
+++ b/src/components/products/hydra/index.js
@@ -31,7 +31,11 @@ export const hydra = {
         },
       ],
     },
-    { ...referencesSection('hydra') },
+    {
+      ...referencesSection('hydra'),
+      href: `https://mpl-hydra-js-docs.vercel.app/`,
+      target: '_blank',
+    },
     { ...recipesSection('hydra') },
     { ...changelogSection('hydra') },
   ],

--- a/src/components/products/inscription/index.js
+++ b/src/components/products/inscription/index.js
@@ -60,6 +60,10 @@ export const inscription = {
         },
       ],
     },
-    { ...referencesSection('inscription') },
+    {
+      ...referencesSection('inscription'),
+      href: `https://mpl-inscription-js-docs.vercel.app/`,
+      target: '_blank',
+    },
   ],
 }

--- a/src/components/products/tokenAuthRules/index.js
+++ b/src/components/products/tokenAuthRules/index.js
@@ -102,6 +102,10 @@ export const tokenAuthRules = {
         },
       ],
     },
-    { ...referencesSection('token-auth-rules') },
+    {
+      ...referencesSection('token-auth-rules'),
+      href: 'https://mpl-token-auth-rules-js-docs.vercel.app/',
+      target: '_blank'
+    },
   ],
 }

--- a/src/components/products/tokenMetadata/index.js
+++ b/src/components/products/tokenMetadata/index.js
@@ -62,7 +62,11 @@ export const tokenMetadata = {
         },
       ],
     },
-    { ...referencesSection('token-metadata') },
+    {
+      ...referencesSection('token-metadata'),
+      href: `https://mpl-token-metadata-js-docs.vercel.app/`,
+      target: '_blank',
+    },
     { ...recipesSection('token-metadata') },
     { ...changelogSection('token-metadata') },
   ],

--- a/src/components/products/toolbox/index.js
+++ b/src/components/products/toolbox/index.js
@@ -30,7 +30,11 @@ export const toolbox = {
         },
       ],
     },
-    { ...referencesSection('toolbox') },
+    {
+      ...referencesSection('toolbox'),
+      href: `https://mpl-toolbox-js-docs.vercel.app/`,
+      target: '_blank',
+    },
     { ...recipesSection('toolbox') },
     { ...changelogSection('toolbox') },
   ],

--- a/src/components/products/umi/index.js
+++ b/src/components/products/umi/index.js
@@ -56,7 +56,11 @@ export const umi = {
         },
       ],
     },
-    { ...referencesSection('umi') },
+    {
+      ...referencesSection('hydra'),
+      href: `https://umi-docs.vercel.app/`,
+      target: '_blank',
+    },
     { ...recipesSection('umi') },
     { ...changelogSection('umi') },
   ],


### PR DESCRIPTION
links API references to the automatically generated typedoc for now.

This is just a temporary fix until the references are baked into the developer hub.