### PR TITLE
Make github header link open in new tab

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -76,6 +76,7 @@ export function Header({ page }) {
             href={page.product.github}
             className="group"
             aria-label="GitHub"
+            target="_blank"
           >
             <GitHubIcon className="h-6 w-6 fill-slate-400 group-hover:fill-slate-500 dark:group-hover:fill-slate-300" />
           </Link>


### PR DESCRIPTION
Found it inconvenient for the github link in the header to redirect within the same tab, as I was usually reading docs and wanting to goto github to look at some source code without losing my place.