### PR TITLE
Fix old docs images and links

### DIFF
--- a/src/pages/bubblegum/verify-collections.md
+++ b/src/pages/bubblegum/verify-collections.md
@@ -8,7 +8,7 @@ Whenever a collection is set on a Compressed NFT, the update authority of the co
 
 Technically, this will toggle a **Verified** boolean on the **Collection** object of the cNFT, letting anyone know that an authority of the collection approved this Compressed NFT as being part of the collection.
 
-If you are not familiar with the concept of collections with regard to NFTs, they are special non-compressed NFTs that can be used to group other NFTs together. The data of the **Collection NFT** is therefore used to describe the name and the branding of the entire collection. You can [read more about Metaplex Certified Collections here](https://docs.metaplex.com/programs/token-metadata/certified-collections).
+If you are not familiar with the concept of collections with regard to NFTs, they are special non-compressed NFTs that can be used to group other NFTs together. The data of the **Collection NFT** is therefore used to describe the name and the branding of the entire collection. You can [read more about Metaplex Verified Collections here](/token-metadata/collections).
 
 Note that is possible to mint a Compressed NFT directly into a collection by using the **Mint to Collection V1** instruction [documented here](/bubblegum/mint-cnfts#minting-to-a-collection). That being said, if you have already minted a cNFT without a collection, let's see how we can verify, unverify but also set the collection on that cNFT.
 

--- a/src/pages/candy-machine-4/index.md
+++ b/src/pages/candy-machine-4/index.md
@@ -19,7 +19,7 @@ The name refers to the vending machines that dispense candy for coins via a mech
 {% /quick-links %}
 
 {% callout %}
-This documentation refers to the latest iteration of Candy Machine known as Candy Machine V3. If you’re looking for Candy Machine V2, [please refer to this documentation instead](https://docs.metaplex.com/deprecated/candy-machine-v2/).
+This documentation refers to the latest iteration of Candy Machine known as Candy Machine V4. It allows minting Core Assets. If you are looking to mint MPL Token Metadata please have a look at [Candy Machine V3](/candy-machine) instead.
 {% /callout %}
 
 ## Introduction

--- a/src/pages/candy-machine-4/sugar/bring-your-own-uploader.md
+++ b/src/pages/candy-machine-4/sugar/bring-your-own-uploader.md
@@ -11,7 +11,7 @@ Sugar has an extensible architecture to easily allow the implementation of new u
 
 The use of the different traits is illustrated in the upload architecture overview below:
 
-![Uploader architecture](https://docs.metaplex.com/assets/images/UploaderOverview-c455b1d9ac30e0c664d77d49e5935b3d.png#radius#shadow)
+![Uploader architecture](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/UploaderOverview.png)
 
 To implement your uploader, the first step is to decide whether you need full control of the upload process or your method support parallel upload. This will inform which trait to implement. Independently of the trait that you implement, assets (files) requiring upload are represented by a `AssetInfo` struct:
 

--- a/src/pages/candy-machine-4/sugar/installation.md
+++ b/src/pages/candy-machine-4/sugar/installation.md
@@ -30,19 +30,17 @@ If you are using Windows, follow the steps below:
 
 3. Right-click on the executable file and go to `Properties`.
 
-   ![Properties.PNG](https://docs.metaplex.com/assets/images/Properties-a728fa4422df37b3700247294874ce06.png#radius#shadow)
+   ![Properties.PNG](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/Properties.png)
 
 4. If you trust the Metaplex developer team, check the `Unblock` button as show in the image below. This will allow you to run this binary on your computer since Microsoft does not trust it automatically.
 
-   ![Unblock.PNG](https://docs.metaplex.com/assets/images/Unblock-bc100bf8d7193682c0a75fa01418d07e.png#radius#shadow)
+   ![Unblock.PNG](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/Unblock.png)
 
 5. Click `Apply` and `Ok`.
 
 6. Double-click the executable file, and it will open a terminal and begin to install Sugar.
 
-7. If everything completed successfully you will get a message saying so.
-
-   ![windows installed](https://docs.metaplex.com/assets/images/installed-2cc250e376836b86f47ed98ab4aca7d2.png#radius#shadow)
+7. If everything completed successfully you will get a message saying `Sugar successfully installed!`
 
 8. Try running `sugar` in your terminal and see if it prints a list of commands you can use. If so you're good to go!
 

--- a/src/pages/candy-machine/index.md
+++ b/src/pages/candy-machine/index.md
@@ -19,7 +19,7 @@ The name refers to the vending machines that dispense candy for coins via a mech
 {% /quick-links %}
 
 {% callout %}
-This documentation refers to the latest iteration of Candy Machine known as Candy Machine V3. If you’re looking for Candy Machine V2, [please refer to this documentation instead](https://docs.metaplex.com/deprecated/candy-machine-v2/).
+This documentation refers to Candy Machine **V3**.
 {% /callout %}
 
 ## Introduction

--- a/src/pages/candy-machine/sugar/bring-your-own-uploader.md
+++ b/src/pages/candy-machine/sugar/bring-your-own-uploader.md
@@ -11,7 +11,7 @@ Sugar has an extensible architecture to easily allow the implementation of new u
 
 The use of the different traits is illustrated in the upload architecture overview below:
 
-![Uploader architecture](https://docs.metaplex.com/assets/images/UploaderOverview-c455b1d9ac30e0c664d77d49e5935b3d.png#radius#shadow)
+![Uploader architecture](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/UploaderOverview.png)
 
 To implement your uploader, the first step is to decide whether you need full control of the upload process or your method support parallel upload. This will inform which trait to implement. Independently of the trait that you implement, assets (files) requiring upload are represented by a `AssetInfo` struct:
 

--- a/src/pages/candy-machine/sugar/installation.md
+++ b/src/pages/candy-machine/sugar/installation.md
@@ -30,11 +30,11 @@ If you are using Windows, follow the steps below:
 
 3. Right-click on the executable file and go to `Properties`.
 
-   ![Properties.PNG](https://docs.metaplex.com/assets/images/Properties-a728fa4422df37b3700247294874ce06.png#radius#shadow)
+   ![Properties.PNG](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/Properties.png)
 
 4. If you trust the Metaplex developer team, check the `Unblock` button as show in the image below. This will allow you to run this binary on your computer since Microsoft does not trust it automatically.
 
-   ![Unblock.PNG](https://docs.metaplex.com/assets/images/Unblock-bc100bf8d7193682c0a75fa01418d07e.png#radius#shadow)
+   ![Unblock.PNG](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/Unblock.png)
 
 5. Click `Apply` and `Ok`.
 
@@ -42,11 +42,11 @@ If you are using Windows, follow the steps below:
 
 7. If everything completed successfully you will get a message saying so.
 
-   ![windows installed](https://docs.metaplex.com/assets/images/installed-2cc250e376836b86f47ed98ab4aca7d2.png#radius#shadow)
+   ![windows installed](https://raw.githubusercontent.com/metaplex-foundation/docs/main/static/assets/sugar/installed.png)
 
 8. Try running `sugar` in your terminal and see if it prints a list of commands you can use. If so you're good to go!
 
-9. Report any errors to the `#sugar` channel on the [Metaplex Discord](https://discord.gg/metaplex).
+9. Report any errors to the `#candy-machine` forum on the [Metaplex Discord](https://discord.gg/metaplex).
    
 {% callout %}
 


### PR DESCRIPTION
Some images were still included from docs.metaplex.com.
Some links pointed to docs.metaplex.com still.

This PR fixes it.