### PR TITLE
docs(token2022PaymentGuard): fix minting code block

### DIFF
--- a/src/pages/candy-machine/guards/token2022-payment.md
+++ b/src/pages/candy-machine/guards/token2022-payment.md
@@ -175,7 +175,7 @@ You may pass the Mint Settings of the Token Payment guard using the `mintArgs` a
 mintV2(umi, {
   // ...
   mintArgs: {
-    tokenPayment: some({
+    token2022Payment: some({
       mint: tokenMint.publicKey,
       destinationAta,
     }),


### PR DESCRIPTION
when minting the user should specify that it is a `token2022Payment` and not a `tokenPayment` otherwise it will pass the token22 ID and it will throw an error