### PR TITLE
patch: remove creators details in master edition docs

### DIFF
--- a/src/pages/core/plugins/master-edition.md
+++ b/src/pages/core/plugins/master-edition.md
@@ -52,9 +52,6 @@ import {
 
 const collectionSigner = generateSigner(umi)
 
-const creator1 = publicKey('11111111111111111111111111111111')
-const creator2 = publicKey('22222222222222222222222222222222')
-
 await createCollectionV1(umi, {
   collection: collectionSigner,
   name: 'My NFT',


### PR DESCRIPTION
I think they add confusion to the example, given that these details can only be added using the Royalty plugin.