### PR TITLE
candy machine docs changes for cu

### DIFF
--- a/src/pages/core-candy-machine/mint.md
+++ b/src/pages/core-candy-machine/mint.md
@@ -106,9 +106,9 @@ const coreCollection = publicKey("22222222222222222222222222222222");
 const asset = generateSigner(umi);
 
 await mintV1(umi, {
-	candyMachine: candyMachineId,
-	asset,
-	collection: coreCollection,
+  candyMachine: candyMachineId,
+  asset,
+  collection: coreCollection,
 }).sendAndConfirm(umi);
 
 ```
@@ -130,16 +130,16 @@ const asset = generateSigner(umi)
 const nftOwner = publicKey('11111111111111111111111111111111')
 
 await transactionBuilder()
-	.add(createMintWithAssociatedToken(umi, { mint: nftMint, owner: nftOwner }))
-	.add(
-		mintV1(umi, {
-			candyMachine: candyMachineId,
-			asset,
-			collection: coreCollection,
-			owner: nftOwner,
-		})
-	)
-	.sendAndConfirm(umi);
+  .add(createMintWithAssociatedToken(umi, { mint: nftMint, owner: nftOwner }))
+  .add(
+    mintV1(umi, {
+      candyMachine: candyMachineId,
+      asset,
+      collection: coreCollection,
+      owner: nftOwner,
+    })
+  )
+  .sendAndConfirm(umi);
 ```
 
 In the rare event that you wish to mint directly from the Core Candy Machine program instead of the Candy Guard Program, you may use the `mintAssetFromCandyMachine` function instead. This function requires the mint authority of the Core Candy Machine to be provided as a signer and accepts an explicit `assetOwner` attribute.
@@ -154,11 +154,11 @@ const coreCollection = publicKey('22222222222222222222222222222222')
 const asset = generateSigner(umi)
 
 await mintAssetFromCandyMachine(umi, {
-	candyMachine: candyMachineId,
-	mintAuthority: umi.identity,
-	assetOwner: umi.identity.publicKey,
-	asset,
-	collection: coreCollection,
+  candyMachine: candyMachineId,
+  mintAuthority: umi.identity,
+  assetOwner: umi.identity.publicKey,
+  asset,
+  collection: coreCollection,
 }).sendAndConfirm(umi);
 ```
 

--- a/src/pages/core-candy-machine/mint.md
+++ b/src/pages/core-candy-machine/mint.md
@@ -91,20 +91,15 @@ If everything went well, an NFT will be created following the parameters configu
 
 Starting from version `1.0` of the Candy Guard program, The mint instruction accepts an additional `minter` signer which can be different than the existing `payer` signer. This allows us to create minting workflows where the wallet that mints the NFT is no longer requires to pay SOL fees — such as storage fees and SOL mint payments — as the `payer` signer will abstract away those fees. Note that the `minter` signer will still need to pay for token-based fees and will be used to validate the configured guards.
 
-Please note that the latest mint instruction relies on the latest Token Metadata instructions which use a fair amount of compute units. As such, you may need to increase the compute unit limit of the transaction to ensure it is successful. Our SDKs may also help with this.
-
 {% dialect-switcher title="Mint from a Core Candy Machine" %}
 {% dialect title="JavaScript" id="js" %}
 
 To mint from a Core Candy Machine via a configured Candy Guard account, you may use the `mintV1` function and provide the mint address and update authority of the collection NFT the minted NFT will belong to. A `minter` signer and `payer` signer may also be provided but they will default to Umi's identity and payer respectively.
 
-As mentioned above, you may need to increase the compute unit limit of the transaction to ensure the `mintV1` instruction is successful. You may do this by using the `setComputeUnitLimit` helper function on the `mpl-toolbox` Umi library as illustrated in the code snippet below.
-
 ```ts
 import { mintV1 } from '@metaplex-foundation/mpl-core-candy-machine'
 import { setComputeUnitLimit } from '@metaplex-foundation/mpl-toolbox'
 import { 
-  transactionBuilder, 
   generateSigner 
 } from '@metaplex-foundation/umi'
 
@@ -112,16 +107,11 @@ const candyMachineId = publicKey('11111111111111111111111111111111')
 const coreCollection = publicKey('22222222222222222222222222222222')
 const asset = generateSigner(umi)
 
-await transactionBuilder()
-  .add(setComputeUnitLimit(umi, { units: 800_000 }))
-  .add(
-    mintV1(umi, {
-      candyMachine: candyMachineId,
-      asset,
-      collection: coreCollection,
-    })
-  )
-  .sendAndConfirm(umi)
+await mintV1(umi, {
+	candyMachine: candyMachineId,
+	asset,
+	collection: coreCollection,
+}).sendAndConfirm(umi);
 ```
 
 Note that the `mintV1` instruction takes care of creating the Mint and Token accounts for us by default and will set the NFT owner to the `minter`. If you wish to create these yourself beforehand, you may simply give the NFT mind address as a public key instead of a signer. Here's an example using the `createMintWithAssociatedToken` function from the `mpl-toolbox` Umi library:
@@ -130,7 +120,6 @@ Note that the `mintV1` instruction takes care of creating the Mint and Token acc
 import { mintV1 } from '@metaplex-foundation/mpl-core-candy-machine'
 import {
   createMintWithAssociatedToken,
-  setComputeUnitLimit,
 } from '@metaplex-foundation/mpl-toolbox'
 import {
   transactionBuilder,
@@ -142,19 +131,16 @@ const asset = generateSigner(umi)
 const nftOwner = publicKey('11111111111111111111111111111111')
 
 await transactionBuilder()
-  .add(setComputeUnitLimit(umi, { units: 800_000 }))
-  .add(
-    createMintWithAssociatedToken(umi, { mint: nftMint, owner: nftOwner })
-    )
-  .add(
-    mintV1(umi, {
-      candyMachine: candyMachineId,
-      asset,
-      collection: coreCollection,
-      owner: nftOwner,
-    })
-  )
-  .sendAndConfirm(umi)
+	.add(createMintWithAssociatedToken(umi, { mint: nftMint, owner: nftOwner }))
+	.add(
+		mintV1(umi, {
+			candyMachine: candyMachineId,
+			asset,
+			collection: coreCollection,
+			owner: nftOwner,
+		})
+	)
+	.sendAndConfirm(umi);
 ```
 
 In the rare event that you wish to mint directly from the Core Candy Machine program instead of the Candy Guard Program, you may use the `mintAssetFromCandyMachine` function instead. This function requires the mint authority of the Core Candy Machine to be provided as a signer and accepts an explicit `assetOwner` attribute.
@@ -168,18 +154,13 @@ const candyMachineId = publicKey('11111111111111111111111111111111')
 const coreCollection = publicKey('22222222222222222222222222222222')
 const asset = generateSigner(umi)
 
-await transactionBuilder()
-  .add(setComputeUnitLimit(umi, { units: 800_000 }))
-  .add(
-    mintAssetFromCandyMachine(umi, {
-      candyMachine: candyMachineId,
-      mintAuthority: umi.identity,
-      assetOwner: umi.identity.publicKey,
-      asset,
-      collection: coreCollection,
-    })
-  )
-  .sendAndConfirm(umi)
+await mintAssetFromCandyMachine(umi, {
+	candyMachine: candyMachineId,
+	mintAuthority: umi.identity,
+	assetOwner: umi.identity.publicKey,
+	asset,
+	collection: coreCollection,
+}).sendAndConfirm(umi);
 ```
 
 API References: [mintV1](https://mpl-core-candy-machine.typedoc.metaplex.com/functions/mintV1.html), [mintAssetFromCandyMachine](https://mpl-core-candy-machine.typedoc.metaplex.com/functions/mintAssetFromCandyMachine.html)
@@ -252,12 +233,16 @@ A good example of a guard that requires Mint Settings is the **NFT Payment** gua
 
 If you were to only use guards that do not require Mint Settings, you may mint in the same way described by the “Basic Minting” section above. Otherwise, you’ll need to provide an additional object attribute containing the Mint Settings of all guards that require them. Let’s have a look at what that looks like in practice using our SDKs.
 
+Please note that you may need to increase the number of computer units depending on the number of candy guards you've created the core candy machine with to ensure the transaction is successful. Our SDKs may also help with this.
+
 {% dialect-switcher title="Mint from a Core Candy Machine with guards" %}
 {% dialect title="JavaScript" id="js" %}
 
 When minting via the Umi library, you may use the `mintArgs` attribute to provide the required **Mint Settings**.
 
 Here’s an example using the **Third Party Signer** guard which requires an additional signer and the **Mint Limit** guard which keeps track of how many times a wallet minted from the Core Candy Machine.
+
+As mentioned above, you may need to increase the compute unit limit of the transaction to ensure the `mintV1` instruction is successful. Current units are set to `300_000` but you can adjust this number as you see fit. You may do this by using the `setComputeUnitLimit` helper function on the `mpl-toolbox` Umi library as illustrated in the code snippet below.
 
 ```ts
 import {
@@ -281,7 +266,7 @@ await create(umi, {
 // Mint from the Core Candy Machine.
 const nftMint = generateSigner(umi)
 await transactionBuilder()
-  .add(setComputeUnitLimit(umi, { units: 800_000 }))
+  .add(setComputeUnitLimit(umi, { units: 300_000 }))
   .add(
     mintV1(umi, {
       candyMachine: candyMachineId,
@@ -438,7 +423,7 @@ const coreCollection = publicKey('22222222222222222222222222222222')
 const asset = generateSigner(umi)
 
 await transactionBuilder()
-  .add(setComputeUnitLimit(umi, { units: 800_000 }))
+  .add(setComputeUnitLimit(umi, { units: 300_000 }))
   .add(
     mintV1(umi, {
       candyMachine: candyMachineId,

--- a/src/pages/core-candy-machine/mint.md
+++ b/src/pages/core-candy-machine/mint.md
@@ -97,21 +97,20 @@ Starting from version `1.0` of the Candy Guard program, The mint instruction acc
 To mint from a Core Candy Machine via a configured Candy Guard account, you may use the `mintV1` function and provide the mint address and update authority of the collection NFT the minted NFT will belong to. A `minter` signer and `payer` signer may also be provided but they will default to Umi's identity and payer respectively.
 
 ```ts
-import { mintV1 } from '@metaplex-foundation/mpl-core-candy-machine'
-import { setComputeUnitLimit } from '@metaplex-foundation/mpl-toolbox'
-import { 
-  generateSigner 
-} from '@metaplex-foundation/umi'
+import { mintV1 } from "@metaplex-foundation/mpl-core-candy-machine";
+import { setComputeUnitLimit } from "@metaplex-foundation/mpl-toolbox";
+import { generateSigner } from "@metaplex-foundation/umi";
 
-const candyMachineId = publicKey('11111111111111111111111111111111')
-const coreCollection = publicKey('22222222222222222222222222222222')
-const asset = generateSigner(umi)
+const candyMachineId = publicKey("11111111111111111111111111111111");
+const coreCollection = publicKey("22222222222222222222222222222222");
+const asset = generateSigner(umi);
 
 await mintV1(umi, {
 	candyMachine: candyMachineId,
 	asset,
 	collection: coreCollection,
 }).sendAndConfirm(umi);
+
 ```
 
 Note that the `mintV1` instruction takes care of creating the Mint and Token accounts for us by default and will set the NFT owner to the `minter`. If you wish to create these yourself beforehand, you may simply give the NFT mind address as a public key instead of a signer. Here's an example using the `createMintWithAssociatedToken` function from the `mpl-toolbox` Umi library:


### PR DESCRIPTION
With Core, I don't think requestion `800_000` compute units is reasonable. 

Remove the paragraph from the basic minting section and introduced it in minting with guards

Reduce initial requested CUs to 300k

Here is the [transaction](https://explorer.solana.com/tx/4nmF8PgkLKFdkJfTmk5yqoRDTFZPtFf87aaguy73cKBVojadvcn3CdA7AKAKXP9kZe83btqpSMLKn8g7BtQmiwvd?cluster=devnet) for a basic mint from a core CM using the sol guard using less that 80k CUs