### PR TITLE
Bubblegum - clarify lead schema / asset id header

### DIFF
--- a/src/pages/bubblegum/mint-cnfts.md
+++ b/src/pages/bubblegum/mint-cnfts.md
@@ -49,7 +49,7 @@ await mintV1(umi, {
 
 ### Get leaf schema and Asset ID from mint transaction {% #get-leaf-schema-from-mint-transaction %}
 
-You can retrieve the leaf and determine the asset ID from the `mintV1` transaction using the `parseLeafFromMintV1Transaction` helper.
+You can retrieve the leaf and determine the asset ID from the `mintV1` transaction using the `parseLeafFromMintV1Transaction` helper. This function parses the Transaction, therefore you have to make sure that it has been finalized before calling `parseLeafFromMintV1Transaction`.
 
 {% dialect-switcher title="Get leaf schema from mint transaction" %}
 {% dialect title="JavaScript" id="js" %}

--- a/src/pages/bubblegum/mint-cnfts.md
+++ b/src/pages/bubblegum/mint-cnfts.md
@@ -47,7 +47,7 @@ await mintV1(umi, {
 {% /dialect %}
 {% /dialect-switcher %}
 
-### Get leaf schema from mint transaction {% #get-leaf-schema-from-mint-transaction %}
+### Get leaf schema and Asset ID from mint transaction {% #get-leaf-schema-from-mint-transaction %}
 
 You can retrieve the leaf and determine the asset ID from the `mintV1` transaction using the `parseLeafFromMintV1Transaction` helper.
 


### PR DESCRIPTION
Some users in discord d issues finding this function. Others tried to use it before the tx was finalized.
This should make it a bit more visible and clarify it.