### PR TITLE
Add links to Japanese guides

### DIFF
--- a/src/components/products/guides/index.js
+++ b/src/components/products/guides/index.js
@@ -120,6 +120,17 @@ export const guides = {
 
           ],
         },
+        {
+          title: 'Translated Guides',
+          links: [
+            {
+              title: 'Japanese 日本語',
+              href: '/guides/translated/japanese',
+              created: '2024-08-14',
+              updated: null, // null means it's never been updated
+            },
+          ],
+        },
       ],
     },
   ],

--- a/src/pages/core/guides/print-editions.md
+++ b/src/pages/core/guides/print-editions.md
@@ -349,6 +349,6 @@ pub async fn create_asset_with_plugin() {
 {% /dialect-switcher %}
 
 ## Further Reading
-- Mint from Candy Machine
+- [Mint from Candy Machine](/core-candy-machine/mint)
 - [Master Edition Plugin](/core/plugins/master-edition)
 - [Edition Plugin](/core/plugins/edition)

--- a/src/pages/guides/translated/japanese.md
+++ b/src/pages/guides/translated/japanese.md
@@ -1,0 +1,19 @@
+---
+title: Japanese 日本語
+metaTitle: Japanese 日本語 | Guides
+description: A selection of guides translated into Japanese.
+---
+
+## Guides
+
+### How to create a token (SPL Token) in Solana
+[Solanaでトークン（SPL Token）を作成する方法](https://developers.metaplex.com/)
+
+### How to create NFTs with Solana
+[SolanaでNFTを作成する方法](https://developers.metaplex.com/)
+
+### How to create a Core NFT Asset
+[Core NFT Assetを作成する方法](https://developers.metaplex.com/)
+
+### How to create an NFT with Token Metadata
+[「Token Metadata」でNFTを作成する方法](https://developers.metaplex.com/)


### PR DESCRIPTION
Preview: https://developer-hub-git-danenbm-translated-guides-metaplex-foundation.vercel.app/guides/translated/japanese

Also fixed link to Core Candy Machine minting page.