### PR TITLE
Updated the Middleware to not trigger on every request

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,29 +1,31 @@
-import { NextResponse,  } from 'next/server'
+import { NextResponse } from 'next/server'
 
-const redirectData = {
-  "/umi/web3js-adapters": {
-    "destination": "/umi/web3js-differences-and-adapters",
-    "permanent": true
-  },
-  "/umi/web3js-differences": {
-    "destination": "/umi/web3js-differences-and-adapters",
-    "permanent": true
-  },
-  "/umi/connecting-to-umi": {
-    "destination": "/umi/getting-started",
-    "permanent": true
+const redirectRules = {
+  "/umi": {
+    "/web3js-adapters": "/umi/web3js-differences-and-adapters",
+    "/web3js-differences": "/umi/web3js-differences-and-adapters",
+    "/connecting-to-umi": "/umi/getting-started",
   },
 }
 
-export async function middleware(request) {
-  const pathname = request.nextUrl.pathname
-  const redirectEntry = redirectData[pathname]
+export function middleware(request) {
+  const { pathname } = request.nextUrl
 
- 
-  if (redirectEntry ) {
-    const statusCode = redirectEntry.permanent ? 308 : 307
-    return NextResponse.redirect(request.nextUrl.origin + redirectEntry.destination, statusCode)
+  for (const [rootPath, subPaths] of Object.entries(redirectRules)) {
+    if (pathname.startsWith(rootPath)) {
+      const subPath = pathname.slice(rootPath.length) || "/"
+      const destination = subPaths[subPath]
+      if (destination) {
+        return NextResponse.redirect(new URL(destination, request.url), 308)
+      }
+    }
   }
- 
+
   return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    '/umi/:path*',
+  ],
 }


### PR DESCRIPTION
Keith flagged that the middleware I implemented was spiking Vercel edge data usage since it was rendering on every invocation. 

After reading the Edge Middleware docs, I implemented the config object with a matcher property. 

By adding this piece of code: 
`export const config = {
  matcher: ['/umi/:path*'],
};`
Now Next.js will only run the middleware on /umi paths and not on very invocation. 