### PR TITLE
added truncate as default to all getAssetWithProof() examples

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
       "Solscan",
       "SPACEBAR",
       "Struct",
+      "unverify",
       "usize"
     ],
   "editor.codeActionsOnSave": {

--- a/src/pages/bubblegum/burn-cnfts.md
+++ b/src/pages/bubblegum/burn-cnfts.md
@@ -21,7 +21,7 @@ If you encounter transaction size errors, consider using `{ truncateCanopy: true
 ```ts
 import { getAssetWithProof, burn } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await burn(umi, {
   ...assetWithProof,
   leafOwner: currentLeafOwner,
@@ -33,7 +33,7 @@ await burn(umi, {
 ```ts
 import { getAssetWithProof, burn } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await burn(umi, {
   ...assetWithProof,
   leafDelegate: currentLeafDelegate,

--- a/src/pages/bubblegum/delegate-cnfts.md
+++ b/src/pages/bubblegum/delegate-cnfts.md
@@ -32,7 +32,7 @@ Additionally, more parameters must be provided to verify the integrity of the Co
 ```ts
 import { getAssetWithProof, delegate } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await delegate(umi, {
   ...assetWithProof,
   leafOwner,
@@ -56,7 +56,7 @@ To revoke an existing Delegate Authority, the owner simply needs to set themselv
 ```ts
 import { getAssetWithProof, delegate } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await delegate(umi, {
   ...assetWithProof,
   leafOwner,

--- a/src/pages/bubblegum/transfer-cnfts.md
+++ b/src/pages/bubblegum/transfer-cnfts.md
@@ -22,7 +22,7 @@ If you encounter transaction size errors, consider using `{ truncateCanopy: true
 ```ts
 import { getAssetWithProof, transfer } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await transfer(umi, {
   ...assetWithProof,
   leafOwner: currentLeafOwner,
@@ -35,7 +35,7 @@ await transfer(umi, {
 ```ts
 import { getAssetWithProof, transfer } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await transfer(umi, {
   ...assetWithProof,
   leafDelegate: currentLeafDelegate,

--- a/src/pages/bubblegum/update-cnfts.md
+++ b/src/pages/bubblegum/update-cnfts.md
@@ -63,7 +63,7 @@ import {
 } from '@metaplex-foundation/mpl-bubblegum'
 
 // Use the helper to fetch the proof.
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 
 // Then we can use it to update metadata for the NFT.
 const updateArgs: UpdateArgsArgs = {
@@ -137,7 +137,7 @@ import {
 import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata'
 
 // Use the helper to fetch the proof.
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 
 // Then we can use it to update metadata for the NFT.
 const updateArgs: UpdateArgsArgs = {

--- a/src/pages/bubblegum/verify-collections.md
+++ b/src/pages/bubblegum/verify-collections.md
@@ -33,7 +33,7 @@ import {
   verifyCollection,
 } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await verifyCollection(umi, {
   ...assetWithProof,
   collectionMint,
@@ -59,7 +59,7 @@ import {
   setAndVerifyCollection,
 } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await setAndVerifyCollection(umi, {
   ...assetWithProof,
   treeCreatorOrDelegate,
@@ -86,7 +86,7 @@ import {
   unverifyCollection,
 } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await unverifyCollection(umi, {
   ...assetWithProof,
   collectionMint,

--- a/src/pages/bubblegum/verify-creators.md
+++ b/src/pages/bubblegum/verify-creators.md
@@ -26,7 +26,7 @@ import {
   verifyCreator,
 } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await verifyCreator(umi, { ...assetWithProof, creator }).sendAndConfirm(umi)
 ```
 
@@ -48,7 +48,7 @@ import {
   unverifyCreator,
 } from '@metaplex-foundation/mpl-bubblegum'
 
-const assetWithProof = await getAssetWithProof(umi, assetId)
+const assetWithProof = await getAssetWithProof(umi, assetId, {truncateCanopy: true});
 await unverifyCreator(umi, { ...assetWithProof, creator }).sendAndConfirm(umi)
 ```
 


### PR DESCRIPTION
```ts
const assetWithProof = await getAssetWithProof(umi, assetId, 
    { truncateCanopy: true }
);
```
to all examples.