### PR TITLE
Lock to @solana/web3.js 1.x for compatibility

### DIFF
--- a/src/pages/umi/getting-started/index.md
+++ b/src/pages/umi/getting-started/index.md
@@ -25,7 +25,7 @@ npm i @metaplex-foundation/umi-bundle-defaults
 ```
 
 ```
-npm i @solana/web3.js
+npm i @solana/web3.js@1
 ```
 
 ### For library authors


### PR DESCRIPTION
Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498