### PR TITLE
Hybrid/missing link

### DIFF
--- a/src/components/products/mpl-hybrid/index.js
+++ b/src/components/products/mpl-hybrid/index.js
@@ -2,9 +2,9 @@ import {
   documentationSection,
   guidesSection,
   referencesSection,
-} from '@/shared/sections'
-import { ArrowsRightLeftIcon } from '@heroicons/react/24/solid'
-import { Hero } from './Hero'
+} from '@/shared/sections';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/solid';
+import { Hero } from './Hero';
 
 export const mplHybrid = {
   name: 'MPL-Hybrid',
@@ -88,8 +88,8 @@ export const mplHybrid = {
               href: '/mpl-hybrid/guides/create-your-first-hybrid-collection',
             },
             {
-              title: 'MPL-404 Hyrbid UI Template',
-              href: '/mpl-hybrid/guides/mpl-404-hyrbid-ui-template',
+              title: 'MPL-404 Hybrid UI Template',
+              href: '/mpl-hybrid/guides/mpl-404-hybrid-ui-template',
               created: '2024-12-16',
             },
           ],

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -13,11 +13,11 @@ const redirectRules = {
   '/guides': {
     '/javascript/how-to-create-an-spl-token-on-solana':
       '/guides/javascript/how-to-create-a-solana-token',
-    '/mpl-hybrid/guides/mpl-404-hyrbid-ui-template':
-      '/mpl-hybrid/guides/mpl-404-hybrid-ui-template',
   },
   '/core/guides/javascript/how-to-create-a-core-nft-asset':
     '/core/guides/javascript/how-to-create-a-core-nft-asset-with-javascript',
+  '/mpl-hybrid/guides/mpl-404-hyrbid-ui-template':
+    '/mpl-hybrid/guides/mpl-404-hybrid-ui-template',
 }
 
 export function middleware(request) {
@@ -48,5 +48,6 @@ export const config = {
     '/toolbox/:path*',
     '/core/guides/javascript/how-to-create-a-core-nft-asset',
     '/guides/javascript/how-to-create-an-spl-token-on-solana',
+    '/mpl-hybrid/guides/mpl-404-hyrbid-ui-template'
   ],
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextResponse } from 'next/server';
 
 const redirectRules = {
   '/umi': {
@@ -13,6 +13,8 @@ const redirectRules = {
   '/guides': {
     '/javascript/how-to-create-an-spl-token-on-solana':
       '/guides/javascript/how-to-create-a-solana-token',
+    '/mpl-hybrid/guides/mpl-404-hyrbid-ui-template':
+      '/mpl-hybrid/guides/mpl-404-hybrid-ui-template',
   },
   '/core/guides/javascript/how-to-create-a-core-nft-asset':
     '/core/guides/javascript/how-to-create-a-core-nft-asset-with-javascript',

--- a/src/pages/mpl-hybrid/guides/index.md
+++ b/src/pages/mpl-hybrid/guides/index.md
@@ -10,6 +10,6 @@ The following Guides for Mpl Hybrid are currently available:
 
 {% quick-link title="Create your first Hybrid Collection" icon="CodeBracketSquare" href="/mpl-hybrid/guides/create-your-first-hybrid-collection" description="Learn how to create an hybrid collection, fully end-to-end!" /%}
 
-{% quick-link title="MPL-404 Hyrbid UI Template" icon="CodeBracketSquare" href="/mpl-hybrid/guides/mpl-404-hyrbid-ui-template" description="Learn how to use the swap UI template" /%}
+{% quick-link title="MPL-404 Hybrid UI Template" icon="CodeBracketSquare" href="/mpl-hybrid/guides/mpl-404-hybrid-ui-template" description="Learn how to use the swap UI template" /%}
 
 {% /quick-links %}

--- a/src/pages/mpl-hybrid/guides/index.md
+++ b/src/pages/mpl-hybrid/guides/index.md
@@ -10,4 +10,6 @@ The following Guides for Mpl Hybrid are currently available:
 
 {% quick-link title="Create your first Hybrid Collection" icon="CodeBracketSquare" href="/mpl-hybrid/guides/create-your-first-hybrid-collection" description="Learn how to create an hybrid collection, fully end-to-end!" /%}
 
+{% quick-link title="MPL-404 Hyrbid UI Template" icon="CodeBracketSquare" href="/mpl-hybrid/guides/mpl-404-hyrbid-ui-template" description="Learn how to use the swap UI template" /%}
+
 {% /quick-links %}


### PR DESCRIPTION
- template guide was missing in the guide index of mpl-hybrid
- url had a typo. renamed and forwarded the old url to the new one through middleware