### PR TITLE
hybrid guide - extend scripts with boilerplate

### DIFF
--- a/src/components/products/guides/index.js
+++ b/src/components/products/guides/index.js
@@ -183,6 +183,12 @@ export const guides = {
               created: '2024-09-20',
               updated: null, // null means it's never been updated
             },
+            {
+              title: 'MPL-Hybrid / MPL-404',
+              href: '/mpl-hybrid/guides',
+              created: '2025-01-06',
+              updated: null, // null means it's never been updated
+            },
           ],
         },
         {


### PR DESCRIPTION
I feel like more boilerplate is better here.
Especially because of the required `publicKey as publicKeySerializer` in the import.