### PR TITLE
Transaction finalization and convertion

### DIFF
--- a/src/pages/bubblegum/mint-cnfts.md
+++ b/src/pages/bubblegum/mint-cnfts.md
@@ -59,16 +59,26 @@ await mintV1(umi, {
 
 You can retrieve the leaf and determine the asset ID from the `mintV1` transaction using the `parseLeafFromMintV1Transaction` helper. This function parses the Transaction, therefore you have to make sure that it has been finalized before calling `parseLeafFromMintV1Transaction`.
 
+{% callout type="note" title="Transaction finalization" %}
+Please make sure that the transaction has been finalized before calling `parseLeafFromMintV1Transaction`.
+{% /callout %}
+
 {% dialect-switcher title="Get leaf schema from mint transaction" %}
 {% dialect title="JavaScript" id="js" %}
 
 ```ts
 import {
     findLeafAssetIdPda,
+    mintV1,
     parseLeafFromMintV1Transaction
 } from "@metaplex-foundation/mpl-bubblegum";
 
-const { signature } = await mintV1(umi, { leafOwner, merkleTree, metadata }).sendAndConfirm(umi, { confirm: { commitment: 'confirmed' } });
+const { signature } = await mintV1(umi, {
+  leafOwner,
+  merkleTree,
+  metadata,
+}).sendAndConfirm(umi, { confirm: { commitment: "confirmed" } });
+
 const leaf: LeafSchema = await parseLeafFromMintV1Transaction(umi, signature);
 const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: leaf.nonce });
 // or const assetId = leaf.id;
@@ -160,11 +170,19 @@ await createNft(umi, {
 
 Again you can retrieve the leaf and determine the asset ID from the `mintToCollectionV1` transaction using the `parseLeafFromMintToCollectionV1Transaction` helper.
 
-{% dialect-switcher title="Get leaf schema from mint to collection transaction" %}
+{% callout type="note" title="Transaction finalization" %}
+Please make sure that the transaction has been finalized before calling `parseLeafFromMintToCollectionV1Transaction`.
+{% /callout %}
+
+{% dialect-switcher title="Get leaf schema from mintToCollectionV1 transaction" %}
 {% dialect title="JavaScript" id="js" %}
 
 ```ts
-import { parseLeafFromMintToCollectionV1Transaction } from '../src';
+import {
+    findLeafAssetIdPda,
+    mintV1,
+    parseLeafFromMintToCollectionV1Transaction
+} from "@metaplex-foundation/mpl-bubblegum";
 
 const { signature } = await mintToCollectionV1(umi, {
   leafOwner,

--- a/src/pages/umi/transactions.md
+++ b/src/pages/umi/transactions.md
@@ -219,7 +219,9 @@ await lutBuilder.sendAndConfirm(umi)
 myBuilder = myBuilder.setAddressLookupTables([lut])
 ```
 
-## Get human readable transaction signature
+## Convert Transaction Signature format
+
+### Get human readable (base58) transaction signature
 
 The `signature` that is returned when sending transactions is of type `Uint8Array`. Therefore to get a string instead that can be copied and, for example opened in an explorer you it is required to deserialize it first like this:
 
@@ -233,6 +235,20 @@ const serializedSignature = base58.deserialize(signature)[0];
 console.log(
         `View Transaction on Explorer: https://explorer.solana.com/tx/${serializedSignature}`
       );
+```
+
+### Convert human readable (base58) transaction signature to Uint8Array
+
+In some cases you might have a base58 encoded transaction signature and you want to convert it to a Uint8Array. For example this might be the case if you copied a transaction signature from an explorer and you want to use it in an umi script. 
+
+This can be done using the `base58.deserialize` method.
+
+```ts
+import { base58 } from "@metaplex-foundation/umi/serializers";
+
+const signature = "4NJhR8zm3G7hU1uhPZaBiTMBCERh4CWp2cF1x2Ly9yCvenrY6oS9hF2PAGfT26odWvb49BktkWkoBPGoXMYUVqkY";
+
+const transaction: Uint8Array = base58.serialize(signature)
 ```
 
 ## Fetching sent transactions


### PR DESCRIPTION
1) Highlighting that to parse the leaf from a transaction the tx has to be finalized in [src/pages/bubblegum/mint-cnfts.md](https://developer-hub-git-mark-umitransaction-metaplex-foundation.vercel.app/bubblegum/mint-cnfts)
2) Adding missing packages in [src/pages/bubblegum/mint-cnfts.md](https://developer-hub-git-mark-umitransaction-metaplex-foundation.vercel.app/bubblegum/mint-cnfts)
3) Add example how to serialize a base58 signature back to uint8Array [src/pages/umi/transactions.md](https://developer-hub-git-mark-umitransaction-metaplex-foundation.vercel.app/umi/transactions#convert-transaction-signature-format)