### PR TITLE
fixed accessability label visability for search bar

### DIFF
--- a/src/styles/docsearch.css
+++ b/src/styles/docsearch.css
@@ -53,6 +53,10 @@
   overflow: hidden !important;
 }
 
+.DocSearch-VisuallyHiddenForAccessibility {
+  visibility: hidden;
+}
+
 .DocSearch-Container {
   position: fixed;
   z-index: 200;


### PR DESCRIPTION
There was a CSS issue regarding accessability labels in which they were not hidden.

This is in reference to https://github.com/metaplex-foundation/developer-hub/issues/220

Added the css class that was being referenced and hidden the elements.
