### PR TITLE
clarify how to set an owner of an core asset on mint

### DIFF
--- a/src/pages/core/create-asset.md
+++ b/src/pages/core/create-asset.md
@@ -92,7 +92,7 @@ A full detailed look at the on chain instruction it can be viewed on [Github](ht
 {% dialect title="JavaScript" id="js" %}
 
 ```ts
-import { generateSigner } from '@metaplex-foundation/umi'
+import { generateSigner, publicKey } from '@metaplex-foundation/umi'
 import { create } from '@metaplex-foundation/mpl-core'
 
 const assetSigner = generateSigner(umi)
@@ -101,6 +101,7 @@ const result = await create(umi, {
   asset: assetSigner,
   name: 'My Asset',
   uri: 'https://example.com/my-asset.json',
+  //owner: publicKey('11111111111111111111111111111111'), //optional to mint into a different wallet
 }).sendAndConfirm(umi)
 ```
 
@@ -225,7 +226,7 @@ MPL Core Assets can be created straight into a collection if your MPL Core Colle
 {% dialect title="JavaScript" id="js" %}
 
 ```ts
-import { generateSigner } from '@metaplex-foundation/umi'
+import { generateSigner, publicKey } from '@metaplex-foundation/umi'
 import {
   createCollection,
   create,
@@ -256,6 +257,7 @@ await create(umi, {
   collection: collection,
   name: 'My Asset',
   uri: 'https://example.com/my-asset.json',
+  //owner: publicKey('11111111111111111111111111111111'), //optional to mint into a different wallet
 }).sendAndConfirm(umi)
 ```
 


### PR DESCRIPTION
Adding the `owner` param in two areas of the create section to clarify to users how to directly mint into in a different wallet. This was requested on discord.

https://developer-hub-git-mintcoretodifferentowner-metaplex-foundation.vercel.app/core/create-asset