### PR TITLE
fix order of aura menu

### DIFF
--- a/src/components/products/aura/index.js
+++ b/src/components/products/aura/index.js
@@ -1,6 +1,6 @@
-import { documentationSection } from '@/shared/sections'
-import { SparklesIcon } from '@heroicons/react/24/outline'
-import { Hero } from './Hero'
+import { documentationSection } from '@/shared/sections';
+import { SparklesIcon } from '@heroicons/react/24/outline';
+import { Hero } from './Hero';
 
 export const aura = {
   name: 'Aura',
@@ -63,12 +63,12 @@ export const aura = {
               href: '/aura/api/v1/das/get-asset',
             },
             {
-              title: 'Get Asset Proof',
-              href: '/aura/api/v1/das/get-asset-proof',
-            },
-            {
               title: 'Get Asset Batch',
               href: '/aura/api/v1/das/get-asset-batch',
+            },
+            {
+              title: 'Get Asset Proof',
+              href: '/aura/api/v1/das/get-asset-proof',
             },
             {
               title: 'Get Asset Proof Batch',


### PR DESCRIPTION
Old order was a bit confusing with
- get Asset
- get Asset Proof
- Get Asset Batch
- Get Asset Proof Batch
![grafik](https://github.com/user-attachments/assets/332d3cbb-bbbc-47dc-912f-5f32248f8988)

This changes the order to have it more logically ordered.