### PR TITLE
add displayOptions to Aura API examples

### DIFF
--- a/src/lib/api/aura/das/getAssestByAuthority.js
+++ b/src/lib/api/aura/das/getAssestByAuthority.js
@@ -44,6 +44,38 @@ const getAssetsByAuthority = {
       type: 'string',
       description: 'Retrieve assets after the specified ID',
     },
+    {
+      name: 'options',
+      type: 'object',
+      description: 'Display options',
+      value: {
+        showCollectionMetadata: {
+          type: 'boolean',
+          description: 'Show collection metadata',
+          value: ['false', 'true'],
+        },
+        showFungible: {
+          type: 'boolean',
+          description: 'Show fungible assets',
+          value: ['false', 'true'],
+        },
+        showInscription: {
+          type: 'boolean',
+          description: 'Show inscription data',
+          value: ['false', 'true'],
+        },
+        showUnverifiedCollections: {
+          type: 'boolean',
+          description: 'Show unverified collections',
+          value: ['false', 'true'],
+        },
+        showZeroBalance: {
+          type: 'boolean',
+          description: 'Show token accounts with zero balance',
+          value: ['false', 'true'],
+        },
+      },
+    },
   ],
   examples: null,
 }

--- a/src/lib/api/aura/das/getAsset.js
+++ b/src/lib/api/aura/das/getAsset.js
@@ -9,6 +9,38 @@ const getAsset = {
       placeholder: 'Public key of the asset',
       required: true,
     },
+    {
+      name: 'options',
+      type: 'object',
+      description: 'Display options',
+      value: {
+        showCollectionMetadata: {
+          type: 'boolean',
+          description: 'Show collection metadata',
+          value: ['false', 'true'],
+        },
+        showFungible: {
+          type: 'boolean',
+          description: 'Show fungible assets',
+          value: ['false', 'true'],
+        },
+        showInscription: {
+          type: 'boolean',
+          description: 'Show inscription data',
+          value: ['false', 'true'],
+        },
+        showUnverifiedCollections: {
+          type: 'boolean',
+          description: 'Show unverified collections',
+          value: ['false', 'true'],
+        },
+        showZeroBalance: {
+          type: 'boolean',
+          description: 'Show token accounts with zero balance',
+          value: ['false', 'true'],
+        },
+      },
+    },
   ],
   examples: [
     {

--- a/src/lib/api/aura/das/getAssetBatch.js
+++ b/src/lib/api/aura/das/getAssetBatch.js
@@ -10,6 +10,38 @@ const getAssetBatch = {
       required: true,
       placeHolder: "Asset Public Key"
     },
+    {
+      name: 'options',
+      type: 'object',
+      description: 'Display options',
+      value: {
+        showCollectionMetadata: {
+          type: 'boolean',
+          description: 'Show collection metadata',
+          value: ['false', 'true'],
+        },
+        showFungible: {
+          type: 'boolean',
+          description: 'Show fungible assets',
+          value: ['false', 'true'],
+        },
+        showInscription: {
+          type: 'boolean',
+          description: 'Show inscription data',
+          value: ['false', 'true'],
+        },
+        showUnverifiedCollections: {
+          type: 'boolean',
+          description: 'Show unverified collections',
+          value: ['false', 'true'],
+        },
+        showZeroBalance: {
+          type: 'boolean',
+          description: 'Show token accounts with zero balance',
+          value: ['false', 'true'],
+        },
+      },
+    },
   ],
   exampleResponse: {
     "jsonrpc": "2.0",

--- a/src/lib/api/aura/das/getAssetsByCreator.js
+++ b/src/lib/api/aura/das/getAssetsByCreator.js
@@ -49,6 +49,38 @@ const getAssetsByCreator = {
         type: 'string',
         description: 'Retrieve assets after the specified ID',
       },
+      {
+        name: 'options',
+        type: 'object',
+        description: 'Display options',
+        value: {
+          showCollectionMetadata: {
+            type: 'boolean',
+            description: 'Show collection metadata',
+            value: ['false', 'true'],
+          },
+          showFungible: {
+            type: 'boolean',
+            description: 'Show fungible assets',
+            value: ['false', 'true'],
+          },
+          showInscription: {
+            type: 'boolean',
+            description: 'Show inscription data',
+            value: ['false', 'true'],
+          },
+          showUnverifiedCollections: {
+            type: 'boolean',
+            description: 'Show unverified collections',
+            value: ['false', 'true'],
+          },
+          showZeroBalance: {
+            type: 'boolean',
+            description: 'Show token accounts with zero balance',
+            value: ['false', 'true'],
+          },
+        },
+      },
     ],
     examples: null,
   }

--- a/src/lib/api/aura/das/getAssetsByGroup.js
+++ b/src/lib/api/aura/das/getAssetsByGroup.js
@@ -1,59 +1,89 @@
-
 const getAssetsByGroup = {
-    description: 'Returns the list of assets given an Group address.',
-    method: 'getAssetsByGroup',
-    params: [
-      {
-        name: 'groupKey',
-        type: 'string',
-        description: 'Grouping Key',
-        placeholder: 'collection',
-        required: true,
-      },
-      {
-        name: 'groupValue',
-        type: 'string',
-        description: 'Value of the group. E.g. Public key of the collection',
-        required: true,
-      },
-      {
-        name: 'sortBy',
-        type: 'object',
-        description: 'Sorting criteria',
-        value: {
-          sortBy: {
-            type: 'option',
-            value: ['created', 'updated', 'recentAction', 'none'],
-          },
-          sortDirection: {
-            type: 'option',
-            value: ['asc', 'desc'],
-          },
+  description: 'Returns the list of assets given an Group address.',
+  method: 'getAssetsByGroup',
+  params: [
+    {
+      name: 'groupKey',
+      type: 'string',
+      description: 'Grouping Key',
+      placeholder: 'collection',
+      required: true,
+    },
+    {
+      name: 'groupValue',
+      type: 'string',
+      description: 'Value of the group. E.g. Public key of the collection',
+      required: true,
+    },
+    {
+      name: 'sortBy',
+      type: 'object',
+      description: 'Sorting criteria',
+      value: {
+        sortBy: {
+          type: 'option',
+          value: ['created', 'updated', 'recentAction', 'none'],
+        },
+        sortDirection: {
+          type: 'option',
+          value: ['asc', 'desc'],
         },
       },
-      {
-        name: 'limit',
-        type: 'number',
-        description: 'Number of assets to return',
+    },
+    {
+      name: 'limit',
+      type: 'number',
+      description: 'Number of assets to return',
+    },
+    {
+      name: 'page',
+      type: 'number',
+      description: 'The index of the "page" to retrieve.',
+    },
+    {
+      name: 'before',
+      type: 'string',
+      description: 'Retrieve assets before the specified ID',
+    },
+    {
+      name: 'after',
+      type: 'string',
+      description: 'Retrieve assets after the specified ID',
+    },
+    {
+      name: 'options',
+      type: 'object',
+      description: 'Display options',
+      value: {
+        showCollectionMetadata: {
+          type: 'boolean',
+          description: 'Show collection metadata',
+          value: ['false', 'true'],
+        },
+        showFungible: {
+          type: 'boolean',
+          description: 'Show fungible assets',
+          value: ['false', 'true'],
+        },
+        showInscription: {
+          type: 'boolean',
+          description: 'Show inscription data',
+          value: ['false', 'true'],
+        },
+        showUnverifiedCollections: {
+          type: 'boolean',
+          description: 'Show unverified collections',
+          value: ['false', 'true'],
+        },
+        showZeroBalance: {
+          type: 'boolean',
+          description: 'Show token accounts with zero balance',
+          value: ['false', 'true'],
+        },
       },
-      {
-        name: 'page',
-        type: 'number',
-        description: 'The index of the "page" to retrieve.',
-      },
-      {
-        name: 'before',
-        type: 'string',
-        description: 'Retrieve assets before the specified ID',
-      },
-      {
-        name: 'after',
-        type: 'string',
-        description: 'Retrieve assets after the specified ID',
-      },
-    ],
-    examples: null,
-  }
-  
-  export default getAssetsByGroup
-  
+    },
+  ],
+  examples: null,
+}
+
+export default getAssetsByGroup

--- a/src/lib/api/aura/das/getAssetsByOwner.js
+++ b/src/lib/api/aura/das/getAssetsByOwner.js
@@ -44,6 +44,38 @@ const getAssetsByOwner = {
       type: 'string',
       description: 'Retrieve assets after the specified ID',
     },
+    {
+      name: 'options',
+      type: 'object',
+      description: 'Display options',
+      value: {
+        showCollectionMetadata: {
+          type: 'boolean',
+          description: 'Show collection metadata',
+          value: ['false', 'true'],
+        },
+        showFungible: {
+          type: 'boolean',
+          description: 'Show fungible assets',
+          value: ['false', 'true'],
+        },
+        showInscription: {
+          type: 'boolean',
+          description: 'Show inscription data',
+          value: ['false', 'true'],
+        },
+        showUnverifiedCollections: {
+          type: 'boolean',
+          description: 'Show unverified collections',
+          value: ['false', 'true'],
+        },
+        showZeroBalance: {
+          type: 'boolean',
+          description: 'Show token accounts with zero balance',
+          value: ['false', 'true'],
+        },
+      },
+    },
   ],
   examples: null,
 }

--- a/src/lib/api/aura/das/searchAssest.js
+++ b/src/lib/api/aura/das/searchAssest.js
@@ -155,6 +155,38 @@ const searchAssets = {
       type: 'string',
       description: 'The value of the JSON URI of the asset',
     },
+    {
+      name: 'options',
+      type: 'object',
+      description: 'Display options',
+      value: {
+        showCollectionMetadata: {
+          type: 'boolean',
+          description: 'Show collection metadata',
+          value: ['false', 'true'],
+        },
+        showFungible: {
+          type: 'boolean',
+          description: 'Show fungible assets',
+          value: ['false', 'true'],
+        },
+        showInscription: {
+          type: 'boolean',
+          description: 'Show inscription data',
+          value: ['false', 'true'],
+        },
+        showUnverifiedCollections: {
+          type: 'boolean',
+          description: 'Show unverified collections',
+          value: ['false', 'true'],
+        },
+        showZeroBalance: {
+          type: 'boolean',
+          description: 'Show token accounts with zero balance',
+          value: ['false', 'true'],
+        },
+      },
+    },
   ],
 }
 


### PR DESCRIPTION
Adds the displayOptions fields that are also currently being implemented into the DAS API SDK