### PR TITLE
moved Aura from top level navigation to Dev Tools category

### DIFF
--- a/src/components/MobileNavigation.jsx
+++ b/src/components/MobileNavigation.jsx
@@ -105,12 +105,12 @@ export function MobileNavigation({ page }) {
           >
             <ComputerDesktopIcon height={20} /> Programs and Tools
           </Link>
-          <Link
+          {/* <Link
             href="/aura"
             className="mt-4 flex items-center gap-2 text-slate-900 dark:text-white"
           >
             <SparklesIcon height={20} /> Aura
-          </Link>
+          </Link> */}
 
           <Link
             href="/guides"

--- a/src/components/products/aura/index.js
+++ b/src/components/products/aura/index.js
@@ -7,7 +7,7 @@ export const aura = {
   headline: 'Indexing and Data Availability Network',
   description:
     'A data network that extends Solana and the Solana Virtual Machine (SVM)',
-  navigationMenuCatergory: 'Aura',
+  navigationMenuCatergory: 'Dev Tools',
   path: 'aura',
   icon: <SparklesIcon />,
   github: 'https://github.com/metaplex-foundation/aura/',

--- a/src/components/products/index.js
+++ b/src/components/products/index.js
@@ -17,7 +17,11 @@ import { tokenAuthRules } from './tokenAuthRules';
 import { tokenMetadata } from './tokenMetadata';
 import { umi } from './umi';
 
-export const productCategories = ['Aura', 'MPL', 'Dev Tools']
+export const productCategories = [
+  // 'Aura', 
+  'MPL', 
+  'Dev Tools'
+]
 
 export const products = [
   global,


### PR DESCRIPTION
Commented out Aura in navigation components so it's easy to put back and changed it's base category form `Aura` to `Dev Tools`