### PR TITLE
fixed CreateV1CpiBuilder invoke_signed example

### DIFF
--- a/src/pages/guides/rust/working-with-rust.md
+++ b/src/pages/guides/rust/working-with-rust.md
@@ -289,9 +289,9 @@ You'll need to pass in the original PDA seeds and bump so that the PDA can be re
 let signers = &[&[b"escrow", ctx.accounts.asset.key(), &[ctx.bumps.pda_escrow]]]
 
 CreateV1CpiBuilder::new()
-        .asset(context.accounts,asset)
+        .asset(context.accounts.asset)
         ...
-        .invoke(signers)
+        .invoke_signed(signers)
 
 ```
 


### PR DESCRIPTION
CreateV1CpiBuilder was being called with invoke while the example was mentioning invoke_signed.