### PR TITLE
add Amman Core Candy Machine Config

### DIFF
--- a/src/pages/amman/pre-made-configs.md
+++ b/src/pages/amman/pre-made-configs.md
@@ -203,5 +203,4 @@ module.exports = {
     storageId: "mock-storage",
     clearOnStart: true,
   },
-   },
- };
+};

--- a/src/pages/amman/pre-made-configs.md
+++ b/src/pages/amman/pre-made-configs.md
@@ -16,7 +16,7 @@ const { LOCALHOST, tmpLedgerDir } = require("@metaplex-foundation/amman");
 module.exports = {
   validator: {
     killRunningValidators: true,
-    accountsCluster: "https://api.metaplex.solana.com",
+    accountsCluster: "https://api.devnet.solana.com	",
     accounts: [
        {
         label: "Bubblegum",
@@ -85,7 +85,7 @@ const { LOCALHOST, tmpLedgerDir } = require("@metaplex-foundation/amman");
 module.exports = {
   validator: {
     killRunningValidators: true,
-    accountsCluster: "https://api.metaplex.solana.com",
+    accountsCluster: "https://api.devnet.solana.com	",
     accounts: [
        {
         label: "Candy Machine v3",
@@ -97,6 +97,74 @@ module.exports = {
         accountId: "Guard1JwRhJkVH6XZhzoYxeBVQe872VH6QggF4BWmS9g",
         executable: true,
       },
+      {
+        label: "Token Metadata Program",
+        accountId: "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+        executable: true,
+      },
+      {
+        label: "Token Auth Rules",
+        accountId: "auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg",
+        executable: true,
+      },
+      {
+        label: "Spl ATA Program",
+        accountId: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        executable: true,
+      },
+      {
+        label: "SPL Token Program",
+        accountId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        executable: true,
+      },
+    ],
+    jsonRpcUrl: LOCALHOST,
+    websocketUrl: "",
+    commitment: "confirmed",
+    ledgerDir: tmpLedgerDir(),
+    resetLedger: true,
+    verifyFees: false,
+    detached: process.env.CI != null,
+  },
+  relay: {
+    enabled: process.env.CI == null,
+    killRunningRelay: true,
+  },
+  storage: {
+    enabled: process.env.CI == null,
+    storageId: "mock-storage",
+    clearOnStart: true,
+  },
+};
+```
+
+## Core Candy Machine
+
+This setup is designed to test and work with Metaplex Core Candy Machine. Compared to the Candy Machine example above different Candy Machine program id and Candy Guard program id are used and the MPL-Core program is added.
+
+```json
+const { LOCALHOST, tmpLedgerDir } = require("@metaplex-foundation/amman");
+
+module.exports = {
+  validator: {
+    killRunningValidators: true,
+    accountsCluster: "https://api.devnet.solana.com",
+    accounts: [
+       {
+        label: "Core Candy Machine",
+        accountId: "CMACYFENjoBMHzapRXyo1JZkVS6EtaDDzkjMrmQLvr4J",
+        executable: true,
+      },
+      {
+        label: "Core Candy Guard",
+        accountId: "CMAGAKJ67e9hRZgfC5SFTbZH8MgEmtqazKXjmkaJjWTJ",
+        executable: true,
+      },
+      {
+        label: "mpl-core",
+        accountId: "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d",
+        executable: true,
+      },      
       {
         label: "Token Metadata Program",
         accountId: "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",

--- a/src/pages/amman/pre-made-configs.md
+++ b/src/pages/amman/pre-made-configs.md
@@ -16,7 +16,7 @@ const { LOCALHOST, tmpLedgerDir } = require("@metaplex-foundation/amman");
 module.exports = {
   validator: {
     killRunningValidators: true,
-    accountsCluster: "https://api.devnet.solana.com	",
+    accountsCluster: "https://api.devnet.solana.com",
     accounts: [
        {
         label: "Bubblegum",
@@ -203,5 +203,5 @@ module.exports = {
     storageId: "mock-storage",
     clearOnStart: true,
   },
-};
-```
+   },
+ };


### PR DESCRIPTION
- Updates the Endpoints used in the example configs
- Adds a Core Candy Machine Example config for easier copy & paste

Updated Page: https://developer-hub-git-mark-ammancorecand-496d80-metaplex-foundation.vercel.app/amman/pre-made-configs