### PR TITLE
Add protocol fees link to overview pages

### DIFF
--- a/src/pages/bubblegum-v2/index.md
+++ b/src/pages/bubblegum-v2/index.md
@@ -6,6 +6,10 @@ description: Provides a high-level overview of Bubblegum V2 and compressed NFTs.
 
 Bubblegum V2 is the latest iteration of the Metaplex Protocol program for creating and interacting with compressed NFTs (cNFTs) on Solana. Built for large-scale operations, Bubblegum V2 preserves all the benefits of the original Bubblegum while introducing powerful new features. Compressed NFTs make it possible to scale the creation of NFTs to new orders of magnitude by rethinking the way we store data onchain. {% .lead %}
 
+{% callout %}
+Please note that certain Bubblegum V2 instructions will require protocol fees. Please review the [Protocol Fees](/protocol-fees) page for up-to-date information.
+{% /callout %}
+
 {% quick-links %}
 
 {% quick-link title="Getting Started" icon="InboxArrowDown" href="/bubblegum-v2/sdk" description="Find the language or library of your choice and get started with compressed NFTs." /%}

--- a/src/pages/core/index.md
+++ b/src/pages/core/index.md
@@ -4,7 +4,11 @@ metaTitle: Overview | Core
 description: Provides a high-level overview of the new Solana NFT Asset standard called Core created by Metaplex.
 ---
 
-Metaplex Core (“Core”) sheds the complexity and technical debt of previous standards and provides a clean and simple core spec for digital assets. This next generation Solana NFT standard uses a single account design, reducing minting costs and improving Solana network load compared to alternatives. It also has a flexible plugin system that allows for developers to modify the behavior and functionality of assets. {% .lead %}
+Metaplex Core ("Core") sheds the complexity and technical debt of previous standards and provides a clean and simple core spec for digital assets. This next generation Solana NFT standard uses a single account design, reducing minting costs and improving Solana network load compared to alternatives. It also has a flexible plugin system that allows for developers to modify the behavior and functionality of assets. {% .lead %}
+
+{% callout %}
+Please note that certain Core instructions will require protocol fees. Please review the [Protocol Fees](/protocol-fees) page for up-to-date information.
+{% /callout %}
 
 Come try out Core's features over at [https://core.metaplex.com/](https://core.metaplex.com/) and mint an Asset yourself!
 

--- a/src/pages/fusion/index.md
+++ b/src/pages/fusion/index.md
@@ -6,6 +6,10 @@ description: Provides a high-level overview of composable NFTs using Fusion.
 
 Fusion is an NFT composability feature powered by the Trifle Program. {% .lead %}
 
+{% callout %}
+Please note that certain Fusion (Trifle) instructions will require protocol fees. Please review the [Protocol Fees](/protocol-fees) page for up-to-date information.
+{% /callout %}
+
 The Trifle Program is built upon the Escrow extension of Token Metadata. It uses a Creator Owned Escrow, or COE, using a Trifle PDA as the creator and manager of the COE. Its purpose is to add onchain tracking and composability around NFT ownership. Additionally, the ability to specify rules and effects around token ownership allows for complex ownership models to be implemented by creators.
 
 🔗 **Helpful links:**

--- a/src/pages/mpl-hybrid/index.md
+++ b/src/pages/mpl-hybrid/index.md
@@ -6,6 +6,10 @@ description: Provides a high-level overview of the framework and onchain protoco
 
 **MPL-404** is a new model for digital assets, web3 games, and onchain communities. At the core of the model is a swap program (**mpl-hybrid**) that trades a fixed number of fungible assets for a non-fungible asset and vice versa. The swap is a dual escrow system, ensuring that all available non-fungible assets are backed by escrowed fungibles and vice versa.
 
+{% callout %}
+Please note that certain MPL-Hybrid instructions will require protocol fees. Please review the [Protocol Fees](/protocol-fees) page for up-to-date information.
+{% /callout %}
+
 ## Swapping
 
 The ability to freely move between fungible and non-fungible assets in a predictable way allows this new asset class (often called **hybrids**) to take advantage of the best aspects of both asset types. **Non-fungible assets can now benefit from the liquidity, distribution, and DeFi opportunities** associated with fungible assets. Conversely, fungible assets can now benefit from the improved utility, collectability, and identity that come from the non-fungible world.

--- a/src/pages/token-metadata/index.md
+++ b/src/pages/token-metadata/index.md
@@ -6,6 +6,10 @@ description: Provides a high-level overview of the Solana NFT standard.
 
 The Token Metadata program is a fundamental program when dealing NFTs and Fungible assets on the Solana blockchain. In this overview, we explain what this program does and how we can leverage its various features at a high level. {% .lead %}
 
+{% callout %}
+Please note that certain Token Metadata instructions will require protocol fees. Please review the [Protocol Fees](/protocol-fees) page for up-to-date information.
+{% /callout %}
+
 {% quick-links %}
 
 {% quick-link title="Getting Started" icon="InboxArrowDown" href="/token-metadata/getting-started" description="Find the language or library of your choice and get started with digital assets on Solana." /%}


### PR DESCRIPTION
Add links to the protocol fees page on relevant protocol overview pages to ensure users are aware of associated costs.

---
[Slack Thread](https://metaplexfoundation.slack.com/archives/C0846S3SK47/p1756839079311119?thread_ts=1756839079.311119&cid=C0846S3SK47)

<a href="https://cursor.com/background-agent?bcId=bc-29bf6830-17ea-4fbb-8497-ba7e42b62cbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29bf6830-17ea-4fbb-8497-ba7e42b62cbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

