### PR TITLE
Make inscription docs more clear

### DIFF
--- a/src/pages/inscription/getting-started/js.md
+++ b/src/pages/inscription/getting-started/js.md
@@ -57,7 +57,7 @@ await initializeFromMint(umi, {
       offset: 0,
     })
   )
-  .sendAndConfirm(umi)
+  .sendAndConfirm(umi, {confirm: {commitment: 'finalized'}})
 
 const inscriptionMetadata = await fetchInscriptionMetadata(
   umi,

--- a/src/pages/inscription/write.md
+++ b/src/pages/inscription/write.md
@@ -4,7 +4,7 @@ metaTitle: Write Inscription Data | Inscription
 description: Learn how to write Data to your Inscription
 ---
 
-After [initializing](initialize) an inscription account data can be written to it. This is also the case for associated inscriptions.
+After [initializing](initialize) an inscription account data can be written to it. This is also the case for associated inscriptions. Make sure that your initialization transaction has been finalized (see [Sending transactions](https://developers.metaplex.com/umi/transactions#sending-transactions)).
 
 {% dialect-switcher title="Write Inscription Data" %}
 {% dialect title="JavaScript" id="js" %}

--- a/src/pages/umi/transactions.md
+++ b/src/pages/umi/transactions.md
@@ -185,6 +185,10 @@ Also note that you may send a transaction without waiting for it to be confirmed
 ```ts
 const signature = await builder.send(umi)
 ```
+Or use `sendAndConfirm()` to wait for the transaction finalization for you. To do that, add `{confirm: {commitment: 'finalized'}}` as an "options" arg.
+```ts
+const confirmResult = await builder.sendAndConfirm(umi, {confirm: {commitment: 'finalized'}})
+```
 
 ## Using address lookup tables
 


### PR DESCRIPTION
Added help for Inscription contract. Writing data is only possible if the initialization transaction has been finalized.