### PR TITLE
docs: update and fix broken example

### DIFF
--- a/src/pages/core/guides/javascript/how-to-create-a-core-nft-asset-with-javascript.md
+++ b/src/pages/core/guides/javascript/how-to-create-a-core-nft-asset-with-javascript.md
@@ -71,6 +71,7 @@ import { create, mplCore } from '@metaplex-foundation/mpl-core'
 import {
   createGenericFile,
   generateSigner,
+  keypairIdentity,
   signerIdentity,
   sol,
 } from '@metaplex-foundation/umi'


### PR DESCRIPTION
Fixed sections:

- Setting up umi With an Existing Wallet
- Full Code Example

### Setting up umi With an Existing Wallet
The loaded keypair wasn't being used as a signer

### Full Code Example
Variable `nftSigner` was being used in console log but wasn't used as asset signer