### PR TITLE
Fix CodeViewer

### DIFF
--- a/src/components/code/CodeTabsWithContext.jsx
+++ b/src/components/code/CodeTabsWithContext.jsx
@@ -197,7 +197,7 @@ export function CodeTabsWithContext({
             displayCode = parts.join('\n\n')
             // Fallback: if sections are empty but full code exists, use that
             // (needed for CLI/bash examples that don't have sectioned code)
-            if (!displayCode && tab.code) {
+            if ((!displayCode || !displayCode.trim()) && tab.code) {
               displayCode = tab.code
             }
           } else {


### PR DESCRIPTION
On Pages where e.g. CLI "code" examples were added they were only shown in the "snippet" view. If "full" view was chosen the content appeared empty. Reason: the component builds the whole code from the imports, setup, main, and output sections. For CLI/bash examples, these sections are intentionally left empty.
This PR adds a fallback: if the built sections result in empty content but tab.code exists, use that instead. This allows CLI and CURL examples to display correctly.