### PR TITLE
Fix Bubblegum v2 program ID to match v1

### DIFF
--- a/src/components/OfficialLinks.jsx
+++ b/src/components/OfficialLinks.jsx
@@ -38,7 +38,7 @@ const stackOverflowLinks = [
 const programs = [
   { name: 'Token Metadata', programId: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s', github: 'https://github.com/metaplex-foundation/mpl-token-metadata', docs: '/smart-contracts/token-metadata' },
   { name: 'Core', programId: 'CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d', github: 'https://github.com/metaplex-foundation/mpl-core', docs: '/smart-contracts/core' },
-  { name: 'Bubblegum v2', programId: 'BGUMzZr2wWfD2yzrXFEMTBqLwfFGaToDgqiSBVP9fSCa', github: 'https://github.com/metaplex-foundation/mpl-bubblegum', docs: '/smart-contracts/bubblegum-v2' },
+  { name: 'Bubblegum v2', programId: 'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY', github: 'https://github.com/metaplex-foundation/mpl-bubblegum', docs: '/smart-contracts/bubblegum-v2' },
   { name: 'Bubblegum', programId: 'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY', github: 'https://github.com/metaplex-foundation/mpl-bubblegum', docs: '/smart-contracts/bubblegum' },
   { name: 'Core Candy Machine', programId: 'CMACYFENjoBMHzapRXyo1JZkVS6EtaDDzkjMrmQLvr4J', github: 'https://github.com/metaplex-foundation/mpl-core-candy-machine/tree/main/programs/candy-machine-core', docs: '/smart-contracts/core-candy-machine' },
   { name: 'Core Candy Guard', programId: 'CMAGAKJ67e9hRZgfC5SFTbZH8MgEmtqazKXjmkaJjWTJ', github: 'https://github.com/metaplex-foundation/mpl-core-candy-machine/tree/main/programs/candy-guard', docs: '/smart-contracts/core-candy-machine/guards' },


### PR DESCRIPTION
The Bubblegum v2 program uses the same program ID as v1: BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY

https://claude.ai/code/session_01X9gh43C1ygj1fVp3ZpGkVv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant update in a UI link/list with no behavioral or security impact beyond correcting a displayed program address.
> 
> **Overview**
> Updates the `Bubblegum v2` entry in `src/components/OfficialLinks.jsx` to use the correct on-chain program ID (matching `Bubblegum`/v1), ensuring the official programs table displays the right address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f165b789a2a1d1226c356e68e460fb2e86f7890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->