### PR TITLE
fix: Space calculation error in oracle-plugin-example

### DIFF
--- a/src/pages/en/smart-contracts/core/guides/oracle-plugin-example.md
+++ b/src/pages/en/smart-contracts/core/guides/oracle-plugin-example.md
@@ -110,7 +110,7 @@ pub struct Oracle {
     pub vault_bump: u8,
 }
 impl Space for Oracle {
-    const INIT_SPACE: usize = 8 + 5 + 1;
+    const INIT_SPACE: usize = 8 + 5 + 1+1;
 }
 ```
 Let's discuss some of the choices made in creating this struct:

--- a/src/pages/ja/smart-contracts/core/guides/oracle-plugin-example.md
+++ b/src/pages/ja/smart-contracts/core/guides/oracle-plugin-example.md
@@ -110,7 +110,7 @@ pub struct Oracle {
     pub vault_bump: u8,
 }
 impl Space for Oracle {
-    const INIT_SPACE: usize = 8 + 5 + 1;
+    const INIT_SPACE: usize = 8 + 5 + 1+1;
 }
 ```
 この構造体を作成する際の選択について説明しましょう：


### PR DESCRIPTION
There was Small error while calculating space in oracle-plugin-example docs.

Given : 
8+5+1

Changed 
8+5+1 +1 

+1 for vault_bump:u8