### PR TITLE
Update agent registration schema to EIP-8004 standard

### DIFF
--- a/src/pages/en/agents/register-agent.md
+++ b/src/pages/en/agents/register-agent.md
@@ -85,7 +85,7 @@ The `agentRegistrationUri` points to a JSON document describing the agent's iden
 
 ```json
 {
-  "type": "agent-registration-v1",
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
   "name": "Plexpert",
   "description": "An informational agent providing help related to Metaplex protocols and tools.",
   "image": "https://arweave.net/agent-avatar-tx-hash",
@@ -108,8 +108,8 @@ The `agentRegistrationUri` points to a JSON document describing the agent's iden
   "active": true,
   "registrations": [
     {
-      "agentId": "AgentAssetPublicKey111111111111111111111111111",
-      "agentRegistry": "solana:mainnet:1DREGFgysWYxLnRnKQnwrxnJQeSMk2HmGaC6whw2B2p"
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
     }
   ],
   "supportedTrust": [
@@ -123,7 +123,7 @@ The `agentRegistrationUri` points to a JSON document describing the agent's iden
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `type` | Yes | Schema identifier. Use `agent-registration-v1`. |
+| `type` | Yes | Schema identifier. Use `https://eips.ethereum.org/EIPS/eip-8004#registration-v1`. |
 | `name` | Yes | Human-readable agent name |
 | `description` | Yes | Natural language description of the agent — what it does, how it works, and how to interact with it |
 | `image` | Yes | Avatar or logo URI |
@@ -150,8 +150,8 @@ Each registration entry links back to an on-chain identity record:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `agentId` | Yes | The agent's on-chain asset public key |
-| `agentRegistry` | Yes | Registry address in `{namespace}:{chainId}:{programId}` format |
+| `agentId` | Yes | The agent's mint address |
+| `agentRegistry` | Yes | Constant registry identifier — use `solana:101:metaplex` |
 
 ## Verify Registration
 

--- a/src/pages/en/agents/run-agent.md
+++ b/src/pages/en/agents/run-agent.md
@@ -102,7 +102,7 @@ The document follows the [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) age
 
 ```json
 {
-  "type": "agent-registration-v1",
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
   "name": "An informational agent providing help related to Metaplex protocols and tools.",
   "description": "An autonomous agent that executes DeFi strategies on Solana.",
   "image": "https://arweave.net/agent-avatar-tx-hash",
@@ -120,8 +120,8 @@ The document follows the [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) age
   "active": true,
   "registrations": [
     {
-      "agentId": "AgentAssetPublicKey111111111111111111111111111",
-      "agentRegistry": "solana:mainnet:1DREGFgysWYxLnRnKQnwrxnJQeSMk2HmGaC6whw2B2p"
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
     }
   ],
   "supportedTrust": ["reputation", "crypto-economic"]


### PR DESCRIPTION
## Summary
Updated agent registration documentation to align with the EIP-8004 standard for agent identity and registration metadata. This includes standardizing the schema type identifier and clarifying the registration field formats.

## Key Changes
- Updated `type` field from `"agent-registration-v1"` to `"https://eips.ethereum.org/EIPS/eip-8004#registration-v1"` to use the official EIP-8004 schema identifier
- Changed `agentId` field description and example from "on-chain asset public key" to "mint address" for clarity
- Updated `agentRegistry` field from dynamic format `{namespace}:{chainId}:{programId}` to constant value `"solana:101:metaplex"`
- Replaced placeholder examples with clearer tokens (`<MINT_ADDRESS>` instead of `AgentAssetPublicKey111111111111111111111111111`)
- Updated documentation in both `register-agent.md` and `run-agent.md` for consistency

## Notable Details
- The registry identifier is now standardized as a constant rather than a configurable format, simplifying agent registration
- Chain ID changed from `mainnet` to `101` (Solana mainnet's numeric identifier)
- Documentation now explicitly references EIP-8004 standard for schema validation

https://claude.ai/code/session_012KX8whQoaDHZqNnQmKhu3p