### PR TITLE
docs: add locale pages for agents section and update to Metaplex 014 …

### DIFF
--- a/src/components/NavList.jsx
+++ b/src/components/NavList.jsx
@@ -117,14 +117,14 @@ export const agentMenuCategory = [
   },
   {
     name: 'Register an Agent',
-    headline: 'Register an agent on the Solana agent registry.',
-    description: 'Register an autonomous agent on the Solana agent registry using Metaplex SDKs.',
+    headline: 'Register an agent on the Metaplex 014 agent registry.',
+    description: 'Register an autonomous agent on the Metaplex 014 agent registry using Metaplex SDKs.',
     navigationMenuCatergory: 'Agents',
     href: '/agents/register-agent',
     localizedNavigation: {
-      ja: { name: 'エージェントを登録', headline: 'Solanaエージェントレジストリにエージェントを登録します。' },
-      ko: { name: '에이전트 등록', headline: 'Solana 에이전트 레지스트리에 에이전트를 등록합니다.' },
-      zh: { name: '注册代理', headline: '在Solana代理注册表上注册代理。' },
+      ja: { name: 'エージェントを登録', headline: 'Metaplex 014エージェントレジストリにエージェントを登録します。' },
+      ko: { name: '에이전트 등록', headline: 'Metaplex 014 에이전트 레지스트리에 에이전트를 등록합니다.' },
+      zh: { name: '注册代理', headline: '在Metaplex 014代理注册表上注册代理。' },
     },
   },
   {

--- a/src/pages/en/agents/register-agent.md
+++ b/src/pages/en/agents/register-agent.md
@@ -1,7 +1,7 @@
 ---
 title: Register an Agent
-metaTitle: Register an Agent on Solana | Metaplex Agent Registry
-description: Register an agent identity on Solana by binding an identity record to an MPL Core asset.
+metaTitle: Register an Agent on Solana | Metaplex 014 Agent Registry
+description: Register an agent identity on the Metaplex 014 agent registry by binding an identity record to an MPL Core asset.
 keywords:
   - register agent
   - agent identity
@@ -20,7 +20,7 @@ created: '02-25-2026'
 updated: '03-12-2026'
 ---
 
-Register an agent on Solana by binding an identity record to an MPL Core asset. {% .lead %}
+Register an agent on the Metaplex 014 agent registry by binding an identity record to an MPL Core asset. {% .lead %}
 
 ## Summary
 

--- a/src/pages/ja/agents/index.md
+++ b/src/pages/ja/agents/index.md
@@ -1,0 +1,22 @@
+---
+title: エージェントキット
+metaTitle: Solanaでエージェントを作成・実行 | エージェントレジストリ | Metaplex
+description: Solana上で自律型エージェントを作成、登録、実行します。Metaplexエージェントスキルとエージェントレジストリを使用してエージェントを管理します。
+tableOfContents: false
+keywords:
+  - Solana agents
+  - Agent Kit
+  - autonomous agents
+  - agent identity
+  - MPL Core
+  - execution delegation
+about:
+  - Autonomous Agents
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '03-11-2026'
+updated: '03-12-2026'
+---
+
+{% product-card-grid category="Agents" /%}

--- a/src/pages/ja/agents/register-agent.md
+++ b/src/pages/ja/agents/register-agent.md
@@ -1,0 +1,210 @@
+---
+title: エージェントを登録
+metaTitle: Solanaでエージェントを登録 | Metaplex 014 Agent Registry
+description: MPL CoreアセットにIDレコードを紐付けて、Metaplex 014エージェントレジストリにエージェントIDを登録します。
+keywords:
+  - register agent
+  - agent identity
+  - MPL Core
+  - AgentIdentity plugin
+  - ERC-8004
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Agent Registration
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-25-2026'
+updated: '03-12-2026'
+---
+
+MPL CoreアセットにIDレコードを紐付けて、Metaplex 014エージェントレジストリにエージェントを登録します。{% .lead %}
+
+## 概要
+
+`registerIdentityV1`命令は、オンチェーンIDレコードをMPL Coreアセットに紐付け、検出可能なPDAを作成し、Transfer、Update、Executeのライフサイクルフックをアタッチします。
+
+- アセットの公開鍵から派生したPDAを**作成**し、オンチェーンでの検出を可能にします
+- `AgentIdentity`プラグインとライフサイクルフックをCoreアセットに**アタッチ**します
+- エージェントメタデータのために[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)に準拠したオフチェーン登録ドキュメントに**リンク**します
+- 既存のMPL Coreアセットと`@metaplex-foundation/mpl-agent-registry` SDKが**必要**です
+
+## クイックスタート
+
+1. [前提条件](#前提条件) — MPL Coreアセットを取得し、SDKをインストール
+2. [エージェントを登録](#エージェントを登録-1) — `registerIdentityV1`を呼び出してIDを紐付け
+3. [エージェント登録ドキュメント](#エージェント登録ドキュメント) — オフチェーンメタデータJSONを作成
+4. [登録を確認](#登録を確認) — IDがアタッチされたことを確認
+5. [完全な例](#完全な例) — エンドツーエンドのコードサンプル
+
+## 学べること
+このガイドでは、以下を含むエージェントの登録方法を説明します：
+
+- MPL CoreアセットにリンクされたIDレコード
+- エージェントをオンチェーンで検出可能にするPDA（Program Derived Address）
+- Transfer、Update、Executeのライフサイクルフックを持つAgentIdentityプラグイン
+
+## 前提条件
+
+登録前にMPL Coreアセットが必要です。まだお持ちでない場合は、[NFTを作成](/nfts/create-nft)をご覧ください。IDプログラム自体の詳細については、[MPL Agent Registry](/smart-contracts/mpl-agent)ドキュメントをご覧ください。
+
+## エージェントを登録
+
+登録により、アセットの公開鍵から派生したPDAが作成され、Transfer、Update、Executeのライフサイクルフックを持つ`AgentIdentity`プラグインがアタッチされます。PDAによりエージェントが検出可能になります。誰でもアセットアドレスからPDAを派生させ、登録済みIDがあるかどうかを確認できます。
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { mplAgentIdentity } from '@metaplex-foundation/mpl-agent-registry';
+import { registerIdentityV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentIdentity());
+
+await registerIdentityV1(umi, {
+  asset: assetPublicKey,
+  collection: collectionPublicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+```
+
+## パラメータ
+
+| パラメータ | 説明 |
+|-----------|-------------|
+| `asset` | 登録するMPL Coreアセット |
+| `collection` | アセットのコレクション（オプション） |
+| `agentRegistrationUri` | オフチェーンのエージェント登録メタデータを指すURI |
+| `payer` | レントと手数料を支払う（デフォルトは`umi.payer`） |
+| `authority` | コレクション権限（デフォルトは`payer`） |
+
+## エージェント登録ドキュメント
+
+`agentRegistrationUri`は、エージェントのID、サービス、メタデータを記述するJSONドキュメントを指します。フォーマットはSolana向けに適応された[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)に準拠しています。JSONファイル（および関連画像）をArweaveなどの永続ストレージプロバイダーにアップロードして公開アクセス可能にしてください。プログラムによるアップロードについては、この[ガイド](/smart-contracts/mpl-hybrid/guides/create-deterministic-metadata-with-turbo)をご覧ください。
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "Plexpert",
+  "description": "An informational agent providing help related to Metaplex protocols and tools.",
+  "image": "https://arweave.net/agent-avatar-tx-hash",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>"
+    },
+    {
+      "name": "A2A",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/agent-card.json",
+      "version": "0.3.0"
+    },
+    {
+      "name": "MCP",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/mcp",
+      "version": "2025-06-18"
+    }
+  ],
+  "active": true,
+  "registrations": [
+    {
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
+    }
+  ],
+  "supportedTrust": [
+    "reputation",
+    "crypto-economic"
+  ]
+}
+```
+
+### フィールド
+
+| フィールド | 必須 | 説明 |
+|-------|----------|-------------|
+| `type` | はい | スキーマ識別子。`https://eips.ethereum.org/EIPS/eip-8004#registration-v1`を使用。 |
+| `name` | はい | 人が読めるエージェント名 |
+| `description` | はい | エージェントの自然言語による説明 — 何をするか、どう動くか、どう操作するか |
+| `image` | はい | アバターまたはロゴのURI |
+| `services` | いいえ | エージェントが公開するサービスエンドポイントの配列（以下参照） |
+| `active` | いいえ | エージェントが現在アクティブかどうか（`true`/`false`） |
+| `registrations` | いいえ | エージェントのIDにリンクバックするオンチェーン登録の配列 |
+| `supportedTrust` | いいえ | エージェントがサポートする信頼モデル（例：`reputation`、`crypto-economic`、`tee-attestation`） |
+
+### サービス
+
+各サービスエントリは、エージェントとのやり取り方法を記述します：
+
+| フィールド | 必須 | 説明 |
+|-------|----------|-------------|
+| `name` | はい | サービスタイプ — 例：`web`、`A2A`、`MCP`、`OASF`、`DID`、`email` |
+| `endpoint` | はい | サービスに到達できるURLまたは識別子 |
+| `version` | いいえ | プロトコルバージョン |
+| `skills` | いいえ | このサービスを通じてエージェントが公開するスキルの配列 |
+| `domains` | いいえ | エージェントが動作するドメインの配列 |
+
+### 登録
+
+各登録エントリは、オンチェーンIDレコードにリンクバックします：
+
+| フィールド | 必須 | 説明 |
+|-------|----------|-------------|
+| `agentId` | はい | エージェントのミントアドレス |
+| `agentRegistry` | はい | 固定のレジストリ識別子 — `solana:101:metaplex`を使用 |
+
+## 登録を確認
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+
+// Check the AgentIdentity plugin
+const agentIdentity = assetData.agentIdentities?.[0];
+console.log(agentIdentity?.uri);               // your registration URI
+console.log(agentIdentity?.lifecycleChecks?.transfer);  // truthy
+console.log(agentIdentity?.lifecycleChecks?.update);    // truthy
+console.log(agentIdentity?.lifecycleChecks?.execute);   // truthy
+```
+
+## 完全な例
+
+```typescript
+import { generateSigner } from '@metaplex-foundation/umi';
+import { create, createCollection } from '@metaplex-foundation/mpl-core';
+import { registerIdentityV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+// 1. Create a collection
+const collection = generateSigner(umi);
+await createCollection(umi, {
+  collection,
+  name: 'Agent Collection',
+  uri: 'https://example.com/collection.json',
+}).sendAndConfirm(umi);
+
+// 2. Create an asset
+const asset = generateSigner(umi);
+await create(umi, {
+  asset,
+  name: 'My Agent',
+  uri: 'https://example.com/agent.json',
+  collection,
+}).sendAndConfirm(umi);
+
+// 3. Register identity
+await registerIdentityV1(umi, {
+  asset: asset.publicKey,
+  collection: collection.publicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+```
+
+## 注意事項
+
+- 登録はアセットごとに1回限りの操作です。すでに登録済みのアセットに対して`registerIdentityV1`を呼び出すと失敗します。
+- `agentRegistrationUri`は永続的にホストされたJSON（例：Arweave）を指す必要があります。URIにアクセスできなくなっても、オンチェーンIDは存在し続けますが、クライアントはエージェントのメタデータを取得できなくなります。
+- `collection`パラメータはオプションですが推奨されます。登録時のコレクションレベルの権限チェックを有効にします。
+- Transfer、Update、Executeのライフサイクルフックは自動的にアタッチされます。これらのフックにより、IDプラグインがアセットに対する操作の承認または拒否に参加できます。
+
+*Metaplexが管理 · 2026年3月検証済み · [GitHubでソースを見る](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/ja/agents/run-agent.md
+++ b/src/pages/ja/agents/run-agent.md
@@ -1,0 +1,157 @@
+---
+title: エージェントデータを読み取る
+metaTitle: Solanaでエージェントデータを読み取る | Metaplex Agent Registry
+description: Solana上でエージェントの登録を確認し、エージェントIDデータを読み取ります。
+keywords:
+  - read agent data
+  - agent identity
+  - AgentIdentity plugin
+  - Asset Signer
+  - agent wallet
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Agent Data
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-25-2026'
+updated: '03-12-2026'
+---
+
+[登録](/agents/register-agent)後にオンチェーンでエージェントIDデータを読み取り、確認します。{% .lead %}
+
+## 概要
+
+エージェントIDデータの読み取り、登録状態の確認、AgentIdentityプラグインの検査、オフチェーン登録ドキュメントの取得、エージェントの内蔵ウォレットアドレスの派生を行います。
+
+- `safeFetchAgentIdentityV1`を使用して**登録を確認** — 未登録アセットには`null`を返します
+- 取得したCoreアセットのURIとライフサイクルフックを直接確認して**AgentIdentityプラグインを検査**
+- オンチェーンURIから**登録ドキュメントを取得**し、エージェントメタデータとサービスエンドポイントを読み取ります
+- `findAssetSignerPda`を使用して**エージェントのウォレットを派生** — 秘密鍵のないPDAがエージェントの資金を保持
+
+## 登録を確認
+
+安全取得メソッドはIDが存在しない場合にスローする代わりに`null`を返すため、アセットが登録されているかどうかのチェックに便利です：
+
+```typescript
+import { safeFetchAgentIdentityV1, findAgentIdentityV1Pda } from '@metaplex-foundation/mpl-agent-registry';
+
+const pda = findAgentIdentityV1Pda(umi, { asset: assetPublicKey });
+const identity = await safeFetchAgentIdentityV1(umi, pda);
+
+console.log('Registered:', identity !== null);
+```
+
+## シードから取得
+
+PDAを手動で派生せずに、アセットの公開鍵から直接IDを取得することもできます：
+
+```typescript
+import { fetchAgentIdentityV1FromSeeds } from '@metaplex-foundation/mpl-agent-registry';
+
+const identity = await fetchAgentIdentityV1FromSeeds(umi, {
+  asset: assetPublicKey,
+});
+```
+
+## AgentIdentityプラグインを確認
+
+登録により`AgentIdentity`プラグインがCoreアセットにアタッチされます。取得したアセットから直接読み取って、登録URIとライフサイクルフックを検査できます：
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+
+const agentIdentity = assetData.agentIdentities?.[0];
+console.log(agentIdentity?.uri);               // registration URI
+console.log(agentIdentity?.lifecycleChecks?.transfer);  // truthy
+console.log(agentIdentity?.lifecycleChecks?.update);    // truthy
+console.log(agentIdentity?.lifecycleChecks?.execute);   // truthy
+```
+
+## 登録ドキュメントを読み取る
+
+`AgentIdentity`プラグインの`uri`は、エージェントの完全なプロファイル（名前、説明、サービスエンドポイントなど）を含むオフチェーンJSONドキュメントを指します。他のURIと同様に取得します：
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+const agentIdentity = assetData.agentIdentities?.[0];
+
+if (agentIdentity?.uri) {
+  const response = await fetch(agentIdentity.uri);
+  const registration = await response.json();
+
+  console.log(registration.name);          // "Plexpert"
+  console.log(registration.description);   // "An informational agent..."
+  console.log(registration.active);        // true
+
+  for (const service of registration.services) {
+    console.log(service.name);             // "web", "A2A", "MCP", etc.
+    console.log(service.endpoint);         // service URL
+    console.log(service.version);          // protocol version (if set)
+  }
+}
+```
+
+このドキュメントは[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)エージェント登録標準に準拠しています。典型的な例は以下の通りです：
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "An informational agent providing help related to Metaplex protocols and tools.",
+  "description": "An autonomous agent that executes DeFi strategies on Solana.",
+  "image": "https://arweave.net/agent-avatar-tx-hash",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>"
+    },
+    {
+      "name": "A2A",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/agent-card.json",
+      "version": "0.3.0"
+    }
+  ],
+  "active": true,
+  "registrations": [
+    {
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
+    }
+  ],
+  "supportedTrust": ["reputation", "crypto-economic"]
+}
+```
+
+フィールドの完全なリファレンスについては、[エージェントを登録](/agents/register-agent#agent-registration-document)をご覧ください。
+
+## エージェントのウォレットを取得
+
+すべてのCoreアセットには**Asset Signer**と呼ばれる内蔵ウォレットがあります。アセットの公開鍵から派生したPDAです。秘密鍵は存在しないため、盗まれることはありません。ウォレットはSOL、トークン、その他のアセットを保持できます。`findAssetSignerPda`でアドレスを派生します：
+
+```typescript
+import { findAssetSignerPda } from '@metaplex-foundation/mpl-core';
+
+const assetSignerPda = findAssetSignerPda(umi, { asset: assetPublicKey });
+
+const balance = await umi.rpc.getBalance(assetSignerPda);
+console.log('Agent wallet:', assetSignerPda);
+console.log('Balance:', balance.basisPoints.toString(), 'lamports');
+```
+
+アドレスは決定論的なので、誰でもアセットの公開鍵からアドレスを派生して資金を送信したり残高を確認したりできます。このウォレットに対して署名できるのは、委任された[エグゼクティブ](/agents/run-an-agent)を通じたCoreの[Execute](/smart-contracts/core/execute-asset-signing)命令によるアセット自身のみです。
+
+アカウントレイアウト、PDA派生の詳細、エラーコードについては、[MPL Agent Registry](/smart-contracts/mpl-agent)スマートコントラクトドキュメントをご覧ください。
+
+## 注意事項
+
+- Asset SignerはPDAです。秘密鍵は存在しません。任意のソースから資金を受け取れますが、発信トランザクションに署名できるのはCoreの[Execute](/smart-contracts/core/execute-asset-signing)命令を通じたアセット自身のみです。
+- `safeFetchAgentIdentityV1`は未登録アセットに対してスローする代わりに`null`を返すため、try/catchなしでの存在チェックに安全です。
+- `findAssetSignerPda`はウォレットアドレスを決定論的に派生します。ネットワークに関係なく同じアドレスが返されるため、同じアセットキーでdevnetとmainnetの両方で使用できます。
+
+*Metaplexが管理 · 2026年3月検証済み · [GitHubでソースを見る](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/ja/agents/run-an-agent.md
+++ b/src/pages/ja/agents/run-an-agent.md
@@ -1,0 +1,216 @@
+---
+title: エージェントを実行
+metaTitle: Solanaでエージェントを実行 | Metaplex Agent Registry
+description: エグゼクティブプロファイルを設定し、実行を委任してSolana上で自律型エージェントを実行します。
+keywords:
+  - run agent
+  - executive profile
+  - execution delegation
+  - Agent Tools
+  - autonomous agent
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Execution Delegation
+  - Solana
+  - Metaplex
+proficiencyLevel: Intermediate
+created: '03-11-2026'
+updated: '03-12-2026'
+---
+
+エグゼクティブプロファイルを設定し、実行を委任してSolana上でエージェントを実行します。{% .lead %}
+
+## 概要
+
+実行委任により、オフチェーンのエグゼクティブがエージェントアセットに代わってトランザクションに署名でき、オンチェーンIDとオフチェーン操作の間のギャップを埋めます。
+
+- **エグゼクティブプロファイルを登録** — ウォレットごとに1回のオンチェーンセットアップで検証可能なオペレーターIDを作成
+- **実行を委任** — アセットオーナーがオンチェーンの委任レコードを通じてエージェントを特定のエグゼクティブにリンク
+- **委任を確認** — 委任レコードPDAを派生し、アカウントが存在するかチェック
+- [登録済みエージェント](/agents/register-agent)と`@metaplex-foundation/mpl-agent-registry`パッケージ（v0.2.0以上）が**必要**
+
+## クイックスタート
+
+1. [委任が必要な理由](#委任が必要な理由) — 委任が解決する問題を理解
+2. [エグゼクティブプロファイルを登録](#エグゼクティブプロファイルを登録) — ウォレットごとに1回のセットアップ
+3. [実行を委任](#実行を委任) — エージェントをエグゼクティブにリンク
+4. [委任を確認](#委任を確認) — 委任レコードの存在を確認
+5. [完全な例](#完全な例) — エンドツーエンドのコードサンプル
+
+## 委任が必要な理由
+
+すべてのCoreアセットには内蔵ウォレット（[Asset Signer](/smart-contracts/core/execute-asset-signing)）があります。秘密鍵のないPDAなので、盗まれることはありません。CoreのExecuteライフサイクルフックを通じて、アセット自身のみがそのウォレットに対して署名できます。
+
+問題は、Solanaがバックグラウンドタスクやオンチェーン推論をサポートしていないことです。エージェントは自分でトランザクションを送信するために起動することができません。オフチェーンの何かがそれを行う必要があります。しかし、エージェントのオーナーもすべてのアクションを承認するためにコンピュータの前に座っている必要はないはずです。
+
+実行委任がこのギャップを埋めます。オーナーは**エグゼクティブ**に委任します。エグゼクティブとは、Executeフックを使用してエージェントに代わってトランザクションに署名する信頼できるオフチェーンオペレーターです。オーナーはすべてのトランザクションのためにオンラインである必要なく、誰がエージェントを実行するかを制御します。
+
+## エグゼクティブとは？
+
+エグゼクティブは、エージェントアセットを操作する権限を持つウォレットを表すオンチェーンプロファイルです。サービスアカウントと考えてください：ウォレットをエグゼクティブとして1回登録すれば、個々のエージェントオーナーがそれに実行を委任できます。
+
+これにより**ID**（エージェントが誰か）と**実行**（誰が操作するか）が分離されます。エグゼクティブプロファイルはウォレットの公開鍵から派生したPDAです（ウォレットごとに1つ）。委任はアセットごとに行われます：エージェントオーナーがエージェントを特定のエグゼクティブにリンクする委任レコードを作成します。1つのエグゼクティブが多数のエージェントを実行でき、オーナーはエージェントのIDに触れることなくエグゼクティブを切り替えられます。
+
+すべてのエグゼクティブプロファイルはオンチェーンに存在するため、レジストリは検証可能なディレクトリとして機能します。誰でもプロファイルを列挙し、エグゼクティブがどのエージェントを操作しているかを確認し、委任履歴を検査できます。これにより、エグゼクティブがオンチェーンの実績に基づいて評価されるレピュテーションレイヤーの基盤が築かれます。
+
+## 前提条件
+
+IDレコードとAgentIdentityプラグインを持つ[登録済みエージェント](/agents/register-agent)と、`@metaplex-foundation/mpl-agent-registry`パッケージ（v0.2.0以上）が必要です。
+
+## エグゼクティブプロファイルを登録
+
+エグゼクティブがエージェントを実行する前に、プロファイルが必要です。これはウォレットごとに1回のセットアップです：
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { mplAgentTools } from '@metaplex-foundation/mpl-agent-registry';
+import { registerExecutiveV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentTools());
+
+await registerExecutiveV1(umi, {
+  payer: umi.payer,
+}).sendAndConfirm(umi);
+```
+
+プロファイルPDAはシード`["executive_profile", <authority>]`から派生されるため、各ウォレットは1つしか持てません。
+
+## 実行を委任
+
+エグゼクティブプロファイルが準備できたら、エージェントアセットのオーナーはそれに実行を委任できます。これにより、エージェントをエグゼクティブにリンクするオンチェーンの委任レコードが作成されます：
+
+```typescript
+import { delegateExecutionV1 } from '@metaplex-foundation/mpl-agent-registry';
+import { findAgentIdentityV1Pda, findExecutiveProfileV1Pda } from '@metaplex-foundation/mpl-agent-registry';
+
+const agentIdentity = findAgentIdentityV1Pda(umi, { asset: agentAssetPublicKey });
+const executiveProfile = findExecutiveProfileV1Pda(umi, { authority: executiveAuthorityPublicKey });
+
+await delegateExecutionV1(umi, {
+  agentAsset: agentAssetPublicKey,
+  agentIdentity,
+  executiveProfile,
+}).sendAndConfirm(umi);
+```
+
+アセットオーナーのみが実行を委任できます。プログラムは以下を検証します：
+
+- エグゼクティブプロファイルが存在すること
+- エージェントアセットが有効なMPL Coreアセットであること
+- エージェントが登録済みIDを持つこと
+- 署名者がアセットオーナーであること
+
+## パラメータ
+
+### RegisterExecutiveV1
+
+| パラメータ | 説明 |
+|-----------|-------------|
+| `payer` | レントと手数料を支払う（権限としても使用） |
+| `authority` | このエグゼクティブプロファイルを所有するウォレット（デフォルトは`payer`） |
+
+### DelegateExecutionV1
+
+| パラメータ | 説明 |
+|-----------|-------------|
+| `agentAsset` | 登録済みエージェントのMPL Coreアセット |
+| `agentIdentity` | アセットのエージェントID PDA |
+| `executiveProfile` | 委任先のエグゼクティブプロファイルPDA |
+| `payer` | レントと手数料を支払う（デフォルトは`umi.payer`） |
+| `authority` | アセットオーナーである必要がある（デフォルトは`payer`） |
+
+## 委任を確認
+
+委任が存在するかどうかを確認するには、委任レコードPDAを派生し、アカウントが存在するかチェックします：
+
+```typescript
+import {
+  findExecutiveProfileV1Pda,
+  findExecutionDelegateRecordV1Pda,
+} from '@metaplex-foundation/mpl-agent-registry';
+
+const executiveProfile = findExecutiveProfileV1Pda(umi, {
+  authority: executiveAuthorityPublicKey,
+});
+
+const delegateRecord = findExecutionDelegateRecordV1Pda(umi, {
+  executiveProfile,
+  agentAsset: agentAssetPublicKey,
+});
+
+const account = await umi.rpc.getAccount(delegateRecord);
+console.log('Delegated:', account.exists);
+```
+
+## 完全な例
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { generateSigner } from '@metaplex-foundation/umi';
+import { create, createCollection } from '@metaplex-foundation/mpl-core';
+import { mplAgentIdentity, mplAgentTools } from '@metaplex-foundation/mpl-agent-registry';
+import {
+  registerIdentityV1,
+  registerExecutiveV1,
+  delegateExecutionV1,
+  findAgentIdentityV1Pda,
+  findExecutiveProfileV1Pda,
+} from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentIdentity())
+  .use(mplAgentTools());
+
+// 1. Create a collection
+const collection = generateSigner(umi);
+await createCollection(umi, {
+  collection,
+  name: 'Agent Collection',
+  uri: 'https://example.com/collection.json',
+}).sendAndConfirm(umi);
+
+// 2. Create an asset
+const asset = generateSigner(umi);
+await create(umi, {
+  asset,
+  name: 'My Agent',
+  uri: 'https://example.com/agent.json',
+  collection,
+}).sendAndConfirm(umi);
+
+// 3. Register identity
+await registerIdentityV1(umi, {
+  asset: asset.publicKey,
+  collection: collection.publicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+
+// 4. Register executive profile
+await registerExecutiveV1(umi, {
+  payer: umi.payer,
+}).sendAndConfirm(umi);
+
+// 5. Delegate execution
+const agentIdentity = findAgentIdentityV1Pda(umi, { asset: asset.publicKey });
+const executiveProfile = findExecutiveProfileV1Pda(umi, { authority: umi.payer.publicKey });
+
+await delegateExecutionV1(umi, {
+  agentAsset: asset.publicKey,
+  agentIdentity,
+  executiveProfile,
+}).sendAndConfirm(umi);
+```
+
+## 注意事項
+
+- 各ウォレットは1つのエグゼクティブプロファイルしか持てません。PDAは`["executive_profile", <authority>]`から派生されるため、同じウォレットで`registerExecutiveV1`を再度呼び出すと失敗します。
+- 委任はアセットごとです。オーナーはエグゼクティブに操作させたい各エージェントに対して個別の委任レコードを作成する必要があります。
+- アセットオーナーのみが実行を委任できます。プログラムはオンチェーンで所有権を検証します。
+- オーナーは異なるエグゼクティブプロファイルで新しい委任レコードを作成することでエグゼクティブを切り替えられます。
+
+アカウントレイアウト、PDA派生の詳細、エラーコードについては、[Agent Tools](/smart-contracts/mpl-agent/tools)スマートコントラクトリファレンスをご覧ください。
+
+*Metaplexが管理 · 2026年3月検証済み · [GitHubでソースを見る](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/ja/agents/skill/how-it-works.md
+++ b/src/pages/ja/agents/skill/how-it-works.md
@@ -1,0 +1,113 @@
+---
+title: 仕組み
+metaTitle: 仕組み | Metaplex スキル
+description: Metaplexスキルのプログレッシブディスクロージャーアーキテクチャを理解します。
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - progressive disclosure
+  - agent skill architecture
+  - task router
+  - SKILL.md
+  - reference files
+about:
+  - Progressive disclosure
+  - Agent Skill architecture
+  - Context management
+proficiencyLevel: Intermediate
+---
+
+Metaplex Skillは**プログレッシブディスクロージャー**を使用して、AIエージェントに必要なコンテキストだけを提供します。トークン使用量を低く抑えながら、すべてのMetaplexプログラムの包括的なカバレッジを提供します。{% .lead %}
+
+## 概要
+
+Metaplex Skillは2層のプログレッシブディスクロージャーアーキテクチャを使用して、トークン使用量を最小限に抑えながらAIエージェントに正確なMetaplex知識を提供します。
+
+- 軽量なルーターファイル（`SKILL.md`）がタスクを特定のリファレンスファイルにマッピング
+- エージェントは現在のタスクに関連するファイルのみを読み取り
+- リファレンスファイルはCLIコマンド、SDKパターン、概念的基盤をカバー
+- アーキテクチャはすべてのMetaplexプログラムをカバーしながらコンテキストを小さく保持
+
+## アーキテクチャ
+
+スキルには2つのレイヤーがあります：
+
+1. **`SKILL.md`** — エージェントが最初に読む軽量なルーターファイル。すべてのプログラムの概要、ツール選択ガイド、タスクを特定のリファレンスファイルにマッピングするタスクルーターテーブルが含まれています。
+
+2. **リファレンスファイル** — CLIセットアップ、プログラム固有のCLIコマンド、SDKパターン、概念的基盤をカバーする詳細ファイル。エージェントは現在のタスクに関連するファイルのみを読み取ります。
+
+## エージェントがMetaplex Skillを使用する方法
+
+エージェントにMetaplexタスクを実行するよう依頼すると：
+
+1. エージェントが`SKILL.md`を読み、タスクタイプを識別
+2. タスクルーターテーブルがエージェントを関連するリファレンスファイルに誘導
+3. エージェントはそれらのファイルのみを読み、正確なコマンドとコードでタスクを実行
+
+例えば、*「devnetでCore NFTを作成して」*と依頼すると、エージェントは`SKILL.md`を読み、これをCLI Coreタスクとして識別し、`cli.md`（共通セットアップ）と`cli-core.md`（Core固有コマンド）を読みます。
+
+## リファレンスファイル
+
+スキルにはアプローチとプログラム別に整理されたリファレンスファイルが含まれています：
+
+### CLIリファレンス
+
+これらのファイルは各プログラムの`mplx` CLIコマンドをカバーします。
+
+| ファイル | 内容 |
+|------|----------|
+| `cli.md` | 共通CLIセットアップ、設定、ツールボックスコマンド |
+| `cli-core.md` | Core NFTとコレクションのCLIコマンド |
+| `cli-token-metadata.md` | Token Metadata NFT/pNFTのCLIコマンド |
+| `cli-bubblegum.md` | 圧縮NFT（cNFT）のCLIコマンド |
+| `cli-candy-machine.md` | Candy MachineセットアップとデプロイのCLIコマンド |
+| `cli-genesis.md` | Genesisトークンローンチのcliコマンド |
+
+### SDKリファレンス
+
+これらのファイルは各プログラムのUmiとKit SDKオペレーションをカバーします。
+
+| ファイル | 内容 |
+|------|----------|
+| `sdk-umi.md` | Umi SDKセットアップと共通パターン |
+| `sdk-core.md` | Umi経由のCore NFTオペレーション |
+| `sdk-token-metadata.md` | Umi経由のToken Metadataオペレーション |
+| `sdk-bubblegum.md` | Umi経由の圧縮NFTオペレーション |
+| `sdk-genesis.md` | Umi経由のGenesisトークンローンチオペレーション |
+| `sdk-token-metadata-kit.md` | Kit SDK経由のToken Metadataオペレーション |
+
+### コンセプト
+
+これらのファイルはアカウント構造やプログラムIDなどの共有知識をカバーします。
+
+| ファイル | 内容 |
+|------|----------|
+| `concepts.md` | アカウント構造、PDA、プログラムID |
+
+## タスクルーター
+
+`SKILL.md`のタスクルーターは、各タスクタイプをエージェントが読むべきファイルにマッピングします：
+
+| タスクタイプ | 読み込まれるファイル |
+|-----------|-------------|
+| CLIオペレーション（共通セットアップ） | `cli.md` |
+| CLI: Core NFT/コレクション | `cli.md` + `cli-core.md` |
+| CLI: Token Metadata NFT | `cli.md` + `cli-token-metadata.md` |
+| CLI: 圧縮NFT（Bubblegum） | `cli.md` + `cli-bubblegum.md` |
+| CLI: Candy Machine（NFTドロップ） | `cli.md` + `cli-candy-machine.md` |
+| CLI: トークンローンチ（Genesis） | `cli.md` + `cli-genesis.md` |
+| CLI: ファンジブルトークン | `cli.md`（ツールボックスセクション） |
+| SDKセットアップ（Umi） | `sdk-umi.md` |
+| SDK: Core NFT | `sdk-umi.md` + `sdk-core.md` |
+| SDK: Token Metadata | `sdk-umi.md` + `sdk-token-metadata.md` |
+| SDK: 圧縮NFT（Bubblegum） | `sdk-umi.md` + `sdk-bubblegum.md` |
+| SDK: Candy Machine（ミント/ガード） | `sdk-umi.md` |
+| SDK: Kit使用のToken Metadata | `sdk-token-metadata-kit.md` |
+| SDK: トークンローンチ（Genesis） | `sdk-umi.md` + `sdk-genesis.md` |
+| アカウント構造、PDA、コンセプト | `concepts.md` |
+
+## 注意事項
+
+- スキルはAIコーディングエージェント向けに設計されており、人間が読むドキュメントとしてレンダリングされない場合があります
+- リファレンスファイルは[Skillリポジトリ](https://github.com/metaplex-foundation/skill)と並行してメンテナンスされ、デベロッパーハブとは独立して更新される場合があります
+- [Agent Skills](https://agentskills.io)フォーマットをサポートしないエージェントでも、手動インストールによりスキルを使用できます

--- a/src/pages/ja/agents/skill/index.md
+++ b/src/pages/ja/agents/skill/index.md
@@ -1,0 +1,84 @@
+---
+title: Metaplex スキル
+metaTitle: Metaplex スキル | エージェント
+description: AIコーディングエージェントにMetaplexプログラム、CLIコマンド、SDKパターンの完全な知識を提供するエージェントスキル。
+keywords:
+  - agent skill
+  - AI coding agent
+  - Claude Code
+  - Cursor
+  - Copilot
+  - Metaplex
+  - Solana
+  - NFT
+about:
+  - Agent Skills
+  - AI-assisted development
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-23-2026'
+updated: '03-04-2026'
+---
+
+Metaplex Skillは[Agent Skill](https://agentskills.io)です。AIコーディングエージェントにMetaplexプログラム、CLIコマンド、SDKパターンの正確で最新の知識を提供するナレッジベースです。{% .lead %}
+
+## 概要
+
+Metaplex Skillは、すべてのMetaplexプログラム、CLIコマンド、SDKパターンの正確な知識をAIコーディングエージェントに提供します。
+
+- Core、Token Metadata、Bubblegum、Candy Machine、Genesisの5つのプログラムをカバー
+- CLI、Umi SDK、Kit SDKの3つのアプローチをサポート
+- Claude Code、Cursor、Copilot、Windsurf、その他の互換エージェントで動作
+- プログレッシブディスクロージャーによりトークン使用量を最小限に抑えながら完全なカバレッジを提供
+
+誤ったAPIやフラグに頼る代わりに、AIエージェントはスキルを参照して初回から正確なコマンドとコードを取得できます。
+
+{% quick-links %}
+
+{% quick-link title="インストール" icon="InboxArrowDown" href="/agents/skill/installation" description="Claude Code、Cursor、Copilot、またはAgent Skillsフォーマットをサポートするエージェントにスキルをインストールします。" /%}
+
+{% quick-link title="仕組み" icon="CodeBracketSquare" href="/agents/skill/how-it-works" description="プログレッシブディスクロージャーがコンテキストを軽量に保ちながら完全なカバレッジを提供する仕組みを学びます。" /%}
+
+{% /quick-links %}
+
+## カバーするプログラム
+
+スキルは5つのMetaplexプログラムとその完全なオペレーションセットをカバーします：
+
+| プログラム | 用途 | CLI | Umi SDK | Kit SDK |
+|---------|---------|-----|---------|---------|
+| **[Core](/smart-contracts/core)** | プラグインとロイヤリティ強制を備えた次世代NFT | Yes | Yes | — |
+| **[Token Metadata](/smart-contracts/token-metadata)** | ファンジブルトークン、NFT、pNFT、エディション | Yes | Yes | Yes |
+| **[Bubblegum](/smart-contracts/bubblegum-v2)** | Merkleツリーによる圧縮NFT | Yes | Yes | — |
+| **[Core Candy Machine](/smart-contracts/core-candy-machine)** | 設定可能なガードを持つNFTドロップ | Yes | Yes | — |
+| **[Genesis](/smart-contracts/genesis)** | 公平な配布によるトークンローンチ | Yes | Yes | — |
+
+## サポートされるオペレーション
+
+スキルはMetaplex開発の3つのアプローチに対するリファレンス資料を提供します：
+
+- **CLI (`mplx`)** — ターミナルからのMetaplexオペレーションの直接実行。アセット作成、アップロード、Candy Machineデプロイ、ツリー作成、転送など。
+- **Umi SDK** — すべてのプログラムをカバーする完全なプログラムアクセス。オーナー/コレクション/クリエイターによる取得、DAS APIクエリ、デリゲート管理、プラグイン設定。
+- **Kit SDK** — 最小限の依存関係で`@solana/kit`を使用したToken Metadataオペレーション。
+
+## 互換性のあるエージェント
+
+スキルは[Agent Skills](https://agentskills.io)フォーマットをサポートするすべてのAIコーディングエージェントで動作します：
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+- [Cursor](https://www.cursor.com/)
+- [GitHub Copilot](https://github.com/features/copilot)
+- [Codex](https://openai.com/index/codex/)
+- [Windsurf](https://windsurf.com/)
+
+## 次のステップ
+
+- **[スキルをインストール](/agents/skill/installation)** して始めましょう
+- **[仕組み](/agents/skill/how-it-works)** でアーキテクチャを理解
+- **[プログラムとオペレーション](/agents/skill/programs-and-operations)** で詳細なカバレッジを確認
+
+## 注意事項
+
+- スキルは[Agent Skills](https://agentskills.io)フォーマットをサポートするAIコーディングエージェントが必要です
+- スキルファイルはプロジェクトにバンドルされる静的リファレンスです。更新するにはインストールコマンドを再実行してください
+- `npx skills add`コマンドにはNode.jsとnpm/npxが必要です

--- a/src/pages/ja/agents/skill/installation.md
+++ b/src/pages/ja/agents/skill/installation.md
@@ -1,0 +1,86 @@
+---
+title: インストール
+metaTitle: インストール | Metaplex スキル
+description: Claude Code、Cursor、Copilot、またはAIコーディングエージェントにMetaplex Skillをインストールします。
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - agent skill installation
+  - Claude Code skills
+  - Cursor skills
+  - Copilot skills
+  - npx skills add
+about:
+  - Agent Skills
+  - AI coding agent configuration
+proficiencyLevel: Beginner
+howToSteps:
+  - Run npx skills add metaplex-foundation/skill in your project directory
+  - Verify installation by asking your agent to perform a Metaplex operation
+howToTools:
+  - npx
+  - Claude Code
+  - Cursor
+  - GitHub Copilot
+---
+
+AIコーディングエージェントがすべてのMetaplexプログラム、CLIコマンド、SDKパターンの正確な知識を持つように、Metaplex Skillをインストールします。{% .lead %}
+
+## 概要
+
+Metaplex Skillは`npx skills` CLIまたはエージェントのスキルディレクトリへのファイルの手動コピーでインストールできます。
+
+- `npx skills add`によるワンコマンドインストール（互換エージェント対応）
+- Claude Code向け手動インストール対応（プロジェクトスコープまたはグローバル）
+- Claude Code、Cursor、Copilot、Windsurf、その他のエージェントで動作
+- エージェントにMetaplexオペレーションの実行を依頼して確認
+
+## skills.sh経由（推奨）
+
+最も手早いインストール方法です。プロジェクトディレクトリで以下を実行：
+
+```bash
+npx skills add metaplex-foundation/skill
+```
+
+これはClaude Code、Cursor、Copilot、Windsurf、および[Agent Skills](https://agentskills.io)フォーマットをサポートするすべてのエージェントで動作します。コマンドはスキルファイルをプロジェクトにダウンロードし、エージェントが自動的に参照できるようにします。
+
+## Claude Code手動インストール
+
+`npx skills`を使用したくない場合は、スキルファイルを手動でコピーできます。
+
+### プロジェクトスコープ
+
+プロジェクトのClaudeスキルディレクトリにスキルファイルをコピーします：
+
+```bash
+mkdir -p .claude/skills/metaplex
+```
+
+次に、[GitHubリポジトリ](https://github.com/metaplex-foundation/skill)の`skills/metaplex/`の内容を`.claude/skills/metaplex/`にコピーします。
+
+### グローバル
+
+すべてのプロジェクトでスキルを利用可能にするには：
+
+```bash
+mkdir -p ~/.claude/skills/metaplex
+```
+
+次に、[GitHubリポジトリ](https://github.com/metaplex-foundation/skill)の`skills/metaplex/`の内容を`~/.claude/skills/metaplex/`にコピーします。
+
+## インストールの確認
+
+インストール後、エージェントにMetaplexオペレーションの実行を依頼します。例えば：
+
+- *「GenesisでトークンをLaunchして」*
+- *「devnetでCore NFTコレクションを作成して」*
+- *「ツリーに圧縮NFTをミントして」*
+
+スキルが正しく読み込まれていれば、エージェントは誤ったフラグやAPIを使わずに正しいCLIコマンドまたはSDKコードを参照します。
+
+## 注意事項
+
+- `npx skills add`コマンドにはNode.jsとnpm/npxのインストールが必要です
+- 手動インストールパスはプロジェクトスコープ（`.claude/skills/`）とグローバル（`~/.claude/skills/`）のセットアップで異なります
+- スキルファイルは静的リファレンスです。最新バージョンに更新するにはインストールコマンドを再実行してください

--- a/src/pages/ja/agents/skill/programs-and-operations.md
+++ b/src/pages/ja/agents/skill/programs-and-operations.md
@@ -1,0 +1,150 @@
+---
+title: プログラムとオペレーション
+metaTitle: プログラムとオペレーション | Metaplex スキル
+description: Metaplex Skillがカバーするプログラムとオペレーションの詳細な内訳。
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - Core
+  - Token Metadata
+  - Bubblegum
+  - Candy Machine
+  - Genesis
+  - mplx CLI
+  - Umi SDK
+  - Kit SDK
+about:
+  - Metaplex programs
+  - CLI operations
+  - SDK operations
+proficiencyLevel: Beginner
+---
+
+Metaplex SkillはCLI、Umi SDK、Kit SDKにまたがる5つのプログラムをカバーします。このページでは、各プログラムがサポートする内容と使い分けの詳細を提供します。{% .lead %}
+
+## 概要
+
+Metaplex Skillは、CLI、Umi SDK、Kit SDKにまたがる5つのMetaplexプログラムとそのツーリングに関する知識をAIエージェントに提供します。
+
+- 5つのプログラム（Core、Token Metadata、Bubblegum、Candy Machine、Genesis）すべてがCLIとUmi SDKをサポート
+- Kit SDKはToken Metadataのみ対応
+- `mplx` CLIはコード不要でほとんどのオペレーションを処理
+- このページでタスクに合ったプログラムとツーリングアプローチを判断
+
+## プログラムカバレッジ
+
+| プログラム | CLI | Umi SDK | Kit SDK |
+|---------|-----|---------|---------|
+| **Core** | Yes | Yes | — |
+| **Token Metadata** | Yes | Yes | Yes |
+| **Bubblegum** | Yes | Yes | — |
+| **Candy Machine** | Yes | Yes | — |
+| **Genesis** | Yes | Yes | — |
+
+## Core
+
+Solanaの次世代NFT標準。Core NFTはToken Metadata NFTよりも大幅に安価で、ロイヤリティ強制、フリーズデリゲート、属性などのプラグインシステムをサポートします。
+
+**CLI** (`mplx core`)：コレクションとアセットの作成・更新、プラグイン管理。
+
+**Umi SDK**：オーナー/コレクション/クリエイターによる取得、プラグイン設定、デリゲート管理を含む完全なプログラムアクセス。
+
+## Token Metadata
+
+オリジナルのMetaplex NFT標準。ファンジブルトークン、NFT、プログラマブルNFT（pNFT）、エディションをサポートします。
+
+**CLI** (`mplx tm`)：ファンジブルトークン、NFT、pNFT、エディションの作成。アセットの転送とバーン。
+
+**Umi SDK**：すべてのToken Metadataオペレーションへの完全なプログラムアクセス。
+
+**Kit SDK**：最小限の依存関係で`@solana/kit`を使用したToken Metadataオペレーション。Umiフレームワークを避けたい場合に便利です。
+
+## Bubblegum（圧縮NFT）
+
+状態圧縮のためのMerkleツリーを使用して大規模にNFTを作成。圧縮NFTは初回のツリー作成後、従来のNFTのほんの一部のコストで済みます。
+
+**CLI** (`mplx bg`)：Merkleツリーの作成、cNFTのミント（バッチ上限約100）、取得、更新、転送、バーン。
+
+**Umi SDK**：完全なプログラムアクセス。約100を超えるバッチやDAS APIクエリにはSDKを使用。
+
+{% callout type="note" %}
+圧縮NFTオペレーションにはDAS対応RPCエンドポイントが必要です。標準のSolana RPCエンドポイントはcNFTオペレーションに必要なDigital Asset Standard APIをサポートしていません。
+{% /callout %}
+
+## Candy Machine
+
+設定可能なミントルール（ガード）でNFTドロップをデプロイ。ガードは誰がミントできるか、いつ、いくらで、何個までかを制御します。
+
+**CLI** (`mplx cm`)：Candy Machineの設定、アイテム挿入、デプロイ。ミントにはSDKが必要。
+
+**Umi SDK**：ミントオペレーションとガード設定を含む完全なプログラムアクセス。
+
+## Genesis
+
+公平な配布とRaydiumへの自動流動性グラデュエーションを備えたトークンローンチプロトコル。
+
+**CLI** (`mplx genesis`)：トークンローンチの作成と管理。
+
+**Umi SDK**：トークンローンチの作成と管理のための完全なプログラムアクセス。
+
+## CLI機能
+
+`mplx` CLIはコード不要でほとんどのMetaplexオペレーションを直接処理できます：
+
+| タスク | CLIサポート |
+|------|-------------|
+| ファンジブルトークン作成 | Yes |
+| Core NFT/コレクション作成 | Yes |
+| TM NFT/pNFT作成 | Yes |
+| TM NFT転送 | Yes |
+| ファンジブルトークン転送 | Yes |
+| Core NFT転送 | SDKのみ |
+| Irysへのアップロード | Yes |
+| Candy Machineドロップ | Yes（セットアップ/設定/挿入 — ミントにはSDKが必要） |
+| 圧縮NFT（cNFT） | Yes（バッチ上限約100、大量の場合はSDKを使用） |
+| SOL残高確認/エアドロップ | Yes |
+| オーナー/コレクションでアセットクエリ | SDKのみ（DAS API） |
+| トークンローンチ（Genesis） | Yes |
+
+## 選択ガイド
+
+タスクに適したプログラムとツーリングを選択するためのガイダンスです。
+
+### NFT: Core vs Token Metadata
+
+| 選択 | 条件 |
+|--------|------|
+| **Core** | 新しいNFTプロジェクト、低コスト、プラグイン、ロイヤリティ強制 |
+| **Token Metadata** | 既存のTMコレクション、エディションが必要、レガシー互換性のためのpNFT |
+
+### 圧縮NFTを使う場合
+
+最小限のコストで数千以上のNFTをミントする場合は**Bubblegum**を使用。初期コストはMerkleツリーの作成で、その後の各ミントはトランザクション手数料のみです。
+
+### Candy Machineを使う場合
+
+ミントルール（許可リスト、開始/終了日、ミント上限、支払いトークンなど）を制御する必要があるNFTドロップには**Core Candy Machine**を使用。
+
+### ファンジブルトークン
+
+ファンジブルトークンには常に**Token Metadata**を使用。
+
+### トークンローンチ
+
+公平な配布メカニズムと自動Raydium流動性グラデュエーションを備えたトークン生成イベントには**Genesis**を使用。
+
+### CLI vs SDK
+
+| 選択 | 条件 |
+|--------|------|
+| **CLI** | デフォルトの選択 — 直接実行、コード不要 |
+| **Umi SDK** | コードが必要、またはCLIでサポートされていないオペレーション |
+| **Kit SDK** | `@solana/kit`を使用し最小限の依存関係を求める場合（Token Metadataのみ） |
+
+## 注意事項
+
+- 圧縮NFT（Bubblegum）オペレーションにはDAS対応RPCエンドポイントが必要です。標準のSolana RPCはDigital Asset Standard APIをサポートしていません
+- Candy MachineのミントにはSDKが必要です。CLIはセットアップ、設定、アイテム挿入のみを処理
+- Core NFTの転送はSDKのみで、CLIでは利用できません
+- オーナーまたはコレクションによるアセットクエリにはDAS API（SDKのみ）が必要
+- Kit SDKのサポートはToken Metadataに限定されています。他のすべてのプログラムはUmiを使用

--- a/src/pages/ja/agents/what-is-an-agent.md
+++ b/src/pages/ja/agents/what-is-an-agent.md
@@ -1,0 +1,51 @@
+---
+title: エージェントとは？
+metaTitle: Solanaのエージェントとは？ | Metaplex Agent Registry
+description: Solana上の自律型エージェントは、内蔵ウォレットとオンチェーンIDレコードを持つMPL Coreアセットです。エージェントID、ウォレット、実行委任の仕組みについて学びます。
+keywords:
+  - Solana agents
+  - autonomous agents
+  - agent identity
+  - MPL Core
+  - execution delegation
+  - Asset Signer
+about:
+  - Autonomous Agents
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '03-12-2026'
+updated: '03-12-2026'
+---
+
+Solana上の自律型エージェントは、[Metaplex Agent Registry](/smart-contracts/mpl-agent)によって管理される内蔵ウォレットとオンチェーンIDレコードを持つ[MPL Core](/smart-contracts/core)アセットです。{% .lead %}
+
+## 概要
+
+エージェントとは、オンチェーンIDに登録され、独自のPDA派生ウォレットで資金を保持できるMPL Coreアセットです。オフチェーンオペレーターに実行が委任されるため、オーナーがすべてのトランザクションを承認する必要なく、エージェントは自律的に行動できます。
+
+- **ID** — PDAレコードと`AgentIdentity`プラグインがCoreアセットに検証可能なIDを紐付けます
+- **ウォレット** — アセットの内蔵PDAウォレット（Asset Signer）はSOL、トークン、その他のアセットを秘密鍵なしで保持します
+- **委任** — オフチェーンのエグゼクティブがCoreのExecuteライフサイクルフックを通じてエージェントに代わってトランザクションに署名します
+- **オーナー制御** — オーナーはエージェントのIDやウォレットを変更することなく、いつでも委任を取り消したり切り替えたりできます
+
+## エージェントアセットの仕組み
+
+すべての[MPL Core](/smart-contracts/core)アセットには内蔵ウォレットがあります。これはアセットの公開鍵から派生したPDAです。秘密鍵は存在しないため、ウォレットが盗まれることはありません。Coreの[Execute](/smart-contracts/core/execute-asset-signing)ライフサイクルフックを通じて、アセット自身のみが自分のウォレットに対して署名できます。
+
+これにより、Coreアセットは自律型エージェントに最適です：
+
+- **アセットがエージェントのIDとなる** — [AgentIdentity](/agents/register-agent)プラグインでオンチェーンに登録されます
+- **アセットのPDAウォレットがエージェントの資金を保持する** — エージェントのみが制御するSOL、トークン、その他のアセット
+- **エグゼクティブがエージェントに代わって行動する** — Solanaにはバックグラウンドタスクやオンチェーン推論がないため、委任された[エグゼクティブ](/agents/run-an-agent)がエージェントに代わってトランザクションに署名します。オーナーはすべてのアクションを承認する必要はありません。
+
+オーナーは完全な制御を保持します。どのエグゼクティブに委任するかを選択し、エージェントのIDやウォレットを変更することなく、いつでも委任を取り消したり切り替えたりできます。
+
+## 次のステップ
+
+- **[スキル](/agents/skill)** — AIコーディングエージェントにMetaplexプログラムの完全な知識を付与
+- **[エージェントを登録](/agents/register-agent)** — MPL CoreアセットにIDレコードを紐付け
+- **[エージェントデータを読み取る](/agents/run-agent)** — 登録を確認し、オンチェーンでエージェントIDを検査
+- **[エージェントを実行](/agents/run-an-agent)** — エグゼクティブプロファイルを設定し、実行を委任
+
+*Metaplexが管理 · 2026年3月検証済み*

--- a/src/pages/ko/agents/index.md
+++ b/src/pages/ko/agents/index.md
@@ -1,0 +1,22 @@
+---
+title: 에이전트 키트
+metaTitle: Solana에서 에이전트 생성 및 실행 | 에이전트 레지스트리 | Metaplex
+description: Solana에서 자율 에이전트를 생성, 등록 및 실행합니다. Metaplex 에이전트 스킬과 에이전트 레지스트리를 사용하여 자율 에이전트를 관리합니다.
+tableOfContents: false
+keywords:
+  - Solana agents
+  - Agent Kit
+  - autonomous agents
+  - agent identity
+  - MPL Core
+  - execution delegation
+about:
+  - Autonomous Agents
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '03-11-2026'
+updated: '03-12-2026'
+---
+
+{% product-card-grid category="Agents" /%}

--- a/src/pages/ko/agents/register-agent.md
+++ b/src/pages/ko/agents/register-agent.md
@@ -1,0 +1,210 @@
+---
+title: 에이전트 등록
+metaTitle: Solana에서 에이전트 등록 | Metaplex 014 Agent Registry
+description: MPL Core 자산에 신원 기록을 바인딩하여 Metaplex 014 에이전트 레지스트리에 에이전트 신원을 등록합니다.
+keywords:
+  - register agent
+  - agent identity
+  - MPL Core
+  - AgentIdentity plugin
+  - ERC-8004
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Agent Registration
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-25-2026'
+updated: '03-12-2026'
+---
+
+MPL Core 자산에 신원 기록을 바인딩하여 Metaplex 014 에이전트 레지스트리에 에이전트를 등록합니다. {% .lead %}
+
+## 요약
+
+`registerIdentityV1` 명령은 온체인 신원 기록을 MPL Core 자산에 바인딩하여 검색 가능한 PDA를 생성하고 Transfer, Update, Execute 라이프사이클 훅을 첨부합니다.
+
+- 자산의 공개 키에서 파생된 PDA를 **생성**하여 온체인 검색 가능성 제공
+- `AgentIdentity` 플러그인과 라이프사이클 훅을 Core 자산에 **첨부**
+- 에이전트 메타데이터를 위한 [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) 준수 오프체인 등록 문서에 **링크**
+- 기존 MPL Core 자산과 `@metaplex-foundation/mpl-agent-registry` SDK가 **필요**
+
+## 빠른 시작
+
+1. [사전 요구사항](#사전-요구사항) — MPL Core 자산 획득 및 SDK 설치
+2. [에이전트 등록](#에이전트-등록-1) — `registerIdentityV1` 호출하여 신원 바인딩
+3. [에이전트 등록 문서](#에이전트-등록-문서) — 오프체인 메타데이터 JSON 생성
+4. [등록 확인](#등록-확인) — 신원이 첨부되었는지 확인
+5. [전체 예제](#전체-예제) — 엔드투엔드 코드 샘플
+
+## 학습 내용
+이 가이드는 다음을 포함하는 에이전트 등록 방법을 보여줍니다:
+
+- MPL Core 자산에 연결된 신원 기록
+- 에이전트를 온체인에서 검색 가능하게 하는 PDA(Program Derived Address)
+- Transfer, Update, Execute 라이프사이클 훅이 있는 AgentIdentity 플러그인
+
+## 사전 요구사항
+
+등록 전에 MPL Core 자산이 필요합니다. 아직 없다면 [NFT 만들기](/nfts/create-nft)를 참조하세요. 신원 프로그램 자체에 대한 자세한 내용은 [MPL Agent Registry](/smart-contracts/mpl-agent) 문서를 참조하세요.
+
+## 에이전트 등록
+
+등록은 자산의 공개 키에서 파생된 PDA를 생성하고 Transfer, Update, Execute 라이프사이클 훅이 있는 `AgentIdentity` 플러그인을 첨부합니다. PDA를 통해 에이전트를 검색할 수 있습니다 — 누구나 자산 주소에서 PDA를 파생하여 등록된 신원이 있는지 확인할 수 있습니다.
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { mplAgentIdentity } from '@metaplex-foundation/mpl-agent-registry';
+import { registerIdentityV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentIdentity());
+
+await registerIdentityV1(umi, {
+  asset: assetPublicKey,
+  collection: collectionPublicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+```
+
+## 매개변수
+
+| 매개변수 | 설명 |
+|-----------|-------------|
+| `asset` | 등록할 MPL Core 자산 |
+| `collection` | 자산의 컬렉션 (선택사항) |
+| `agentRegistrationUri` | 오프체인 에이전트 등록 메타데이터를 가리키는 URI |
+| `payer` | 렌트 및 수수료 지불 (기본값: `umi.payer`) |
+| `authority` | 컬렉션 권한 (기본값: `payer`) |
+
+## 에이전트 등록 문서
+
+`agentRegistrationUri`는 에이전트의 신원, 서비스 및 메타데이터를 설명하는 JSON 문서를 가리킵니다. 형식은 Solana에 맞게 조정된 [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)를 따릅니다. JSON(및 관련 이미지)을 Arweave와 같은 영구 스토리지 제공자에 업로드하여 공개적으로 접근 가능하게 하세요. 프로그래밍 방식의 업로드에 대해서는 이 [가이드](/smart-contracts/mpl-hybrid/guides/create-deterministic-metadata-with-turbo)를 참조하세요.
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "Plexpert",
+  "description": "An informational agent providing help related to Metaplex protocols and tools.",
+  "image": "https://arweave.net/agent-avatar-tx-hash",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>"
+    },
+    {
+      "name": "A2A",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/agent-card.json",
+      "version": "0.3.0"
+    },
+    {
+      "name": "MCP",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/mcp",
+      "version": "2025-06-18"
+    }
+  ],
+  "active": true,
+  "registrations": [
+    {
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
+    }
+  ],
+  "supportedTrust": [
+    "reputation",
+    "crypto-economic"
+  ]
+}
+```
+
+### 필드
+
+| 필드 | 필수 | 설명 |
+|-------|----------|-------------|
+| `type` | 예 | 스키마 식별자. `https://eips.ethereum.org/EIPS/eip-8004#registration-v1` 사용. |
+| `name` | 예 | 사람이 읽을 수 있는 에이전트 이름 |
+| `description` | 예 | 에이전트에 대한 자연어 설명 — 무엇을 하는지, 어떻게 작동하는지, 어떻게 상호작용하는지 |
+| `image` | 예 | 아바타 또는 로고 URI |
+| `services` | 아니오 | 에이전트가 노출하는 서비스 엔드포인트 배열 (아래 참조) |
+| `active` | 아니오 | 에이전트가 현재 활성 상태인지 여부 (`true`/`false`) |
+| `registrations` | 아니오 | 에이전트의 신원에 다시 연결되는 온체인 등록 배열 |
+| `supportedTrust` | 아니오 | 에이전트가 지원하는 신뢰 모델 (예: `reputation`, `crypto-economic`, `tee-attestation`) |
+
+### 서비스
+
+각 서비스 항목은 에이전트와 상호작용하는 방법을 설명합니다:
+
+| 필드 | 필수 | 설명 |
+|-------|----------|-------------|
+| `name` | 예 | 서비스 유형 — 예: `web`, `A2A`, `MCP`, `OASF`, `DID`, `email` |
+| `endpoint` | 예 | 서비스에 도달할 수 있는 URL 또는 식별자 |
+| `version` | 아니오 | 프로토콜 버전 |
+| `skills` | 아니오 | 이 서비스를 통해 에이전트가 노출하는 스킬 배열 |
+| `domains` | 아니오 | 에이전트가 운영하는 도메인 배열 |
+
+### 등록
+
+각 등록 항목은 온체인 신원 기록에 다시 연결됩니다:
+
+| 필드 | 필수 | 설명 |
+|-------|----------|-------------|
+| `agentId` | 예 | 에이전트의 민트 주소 |
+| `agentRegistry` | 예 | 고정 레지스트리 식별자 — `solana:101:metaplex` 사용 |
+
+## 등록 확인
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+
+// Check the AgentIdentity plugin
+const agentIdentity = assetData.agentIdentities?.[0];
+console.log(agentIdentity?.uri);               // your registration URI
+console.log(agentIdentity?.lifecycleChecks?.transfer);  // truthy
+console.log(agentIdentity?.lifecycleChecks?.update);    // truthy
+console.log(agentIdentity?.lifecycleChecks?.execute);   // truthy
+```
+
+## 전체 예제
+
+```typescript
+import { generateSigner } from '@metaplex-foundation/umi';
+import { create, createCollection } from '@metaplex-foundation/mpl-core';
+import { registerIdentityV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+// 1. Create a collection
+const collection = generateSigner(umi);
+await createCollection(umi, {
+  collection,
+  name: 'Agent Collection',
+  uri: 'https://example.com/collection.json',
+}).sendAndConfirm(umi);
+
+// 2. Create an asset
+const asset = generateSigner(umi);
+await create(umi, {
+  asset,
+  name: 'My Agent',
+  uri: 'https://example.com/agent.json',
+  collection,
+}).sendAndConfirm(umi);
+
+// 3. Register identity
+await registerIdentityV1(umi, {
+  asset: asset.publicKey,
+  collection: collection.publicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+```
+
+## 참고사항
+
+- 등록은 자산당 1회 작업입니다. 이미 등록된 자산에 대해 `registerIdentityV1`을 호출하면 실패합니다.
+- `agentRegistrationUri`는 영구적으로 호스팅된 JSON(예: Arweave)을 가리켜야 합니다. URI에 접근할 수 없게 되더라도 온체인 신원은 여전히 존재하지만 클라이언트는 에이전트의 메타데이터를 가져올 수 없습니다.
+- `collection` 매개변수는 선택사항이지만 권장됩니다 — 등록 시 컬렉션 수준 권한 검사를 활성화합니다.
+- Transfer, Update, Execute 라이프사이클 훅은 자동으로 첨부됩니다. 이러한 훅을 통해 신원 플러그인이 자산에 대한 작업의 승인 또는 거부에 참여할 수 있습니다.
+
+*Metaplex 관리 · 2026년 3월 검증 완료 · [GitHub에서 소스 보기](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/ko/agents/run-agent.md
+++ b/src/pages/ko/agents/run-agent.md
@@ -1,0 +1,157 @@
+---
+title: 에이전트 데이터 읽기
+metaTitle: Solana에서 에이전트 데이터 읽기 | Metaplex Agent Registry
+description: Solana에서 에이전트 등록을 확인하고 에이전트 신원 데이터를 읽습니다.
+keywords:
+  - read agent data
+  - agent identity
+  - AgentIdentity plugin
+  - Asset Signer
+  - agent wallet
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Agent Data
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-25-2026'
+updated: '03-12-2026'
+---
+
+[등록](/agents/register-agent) 후 온체인에서 에이전트 신원 데이터를 읽고 확인합니다. {% .lead %}
+
+## 요약
+
+에이전트 신원 데이터 읽기, 등록 상태 확인, AgentIdentity 플러그인 검사, 오프체인 등록 문서 가져오기, 에이전트의 내장 지갑 주소 파생.
+
+- `safeFetchAgentIdentityV1`을 사용하여 **등록 확인** — 미등록 자산에 대해 `null` 반환
+- 가져온 Core 자산에서 URI와 라이프사이클 훅을 직접 확인하여 **AgentIdentity 플러그인 검사**
+- 온체인 URI에서 **등록 문서 가져오기**로 에이전트 메타데이터와 서비스 엔드포인트 읽기
+- `findAssetSignerPda`를 사용하여 **에이전트의 지갑 파생** — 개인 키가 없는 PDA가 에이전트의 자금 보유
+
+## 등록 확인
+
+안전 가져오기 메서드는 신원이 존재하지 않을 때 throw 대신 `null`을 반환하여 자산이 등록되었는지 확인하는 데 유용합니다:
+
+```typescript
+import { safeFetchAgentIdentityV1, findAgentIdentityV1Pda } from '@metaplex-foundation/mpl-agent-registry';
+
+const pda = findAgentIdentityV1Pda(umi, { asset: assetPublicKey });
+const identity = await safeFetchAgentIdentityV1(umi, pda);
+
+console.log('Registered:', identity !== null);
+```
+
+## 시드에서 가져오기
+
+PDA를 수동으로 파생하지 않고 자산의 공개 키에서 직접 신원을 가져올 수도 있습니다:
+
+```typescript
+import { fetchAgentIdentityV1FromSeeds } from '@metaplex-foundation/mpl-agent-registry';
+
+const identity = await fetchAgentIdentityV1FromSeeds(umi, {
+  asset: assetPublicKey,
+});
+```
+
+## AgentIdentity 플러그인 확인
+
+등록은 Core 자산에 `AgentIdentity` 플러그인을 첨부합니다. 가져온 자산에서 직접 읽어 등록 URI와 라이프사이클 훅을 검사할 수 있습니다:
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+
+const agentIdentity = assetData.agentIdentities?.[0];
+console.log(agentIdentity?.uri);               // registration URI
+console.log(agentIdentity?.lifecycleChecks?.transfer);  // truthy
+console.log(agentIdentity?.lifecycleChecks?.update);    // truthy
+console.log(agentIdentity?.lifecycleChecks?.execute);   // truthy
+```
+
+## 등록 문서 읽기
+
+`AgentIdentity` 플러그인의 `uri`는 에이전트의 전체 프로필(이름, 설명, 서비스 엔드포인트 등)을 포함하는 오프체인 JSON 문서를 가리킵니다. 다른 URI처럼 가져옵니다:
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+const agentIdentity = assetData.agentIdentities?.[0];
+
+if (agentIdentity?.uri) {
+  const response = await fetch(agentIdentity.uri);
+  const registration = await response.json();
+
+  console.log(registration.name);          // "Plexpert"
+  console.log(registration.description);   // "An informational agent..."
+  console.log(registration.active);        // true
+
+  for (const service of registration.services) {
+    console.log(service.name);             // "web", "A2A", "MCP", etc.
+    console.log(service.endpoint);         // service URL
+    console.log(service.version);          // protocol version (if set)
+  }
+}
+```
+
+이 문서는 [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) 에이전트 등록 표준을 따릅니다. 일반적인 형태는 다음과 같습니다:
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "An informational agent providing help related to Metaplex protocols and tools.",
+  "description": "An autonomous agent that executes DeFi strategies on Solana.",
+  "image": "https://arweave.net/agent-avatar-tx-hash",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>"
+    },
+    {
+      "name": "A2A",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/agent-card.json",
+      "version": "0.3.0"
+    }
+  ],
+  "active": true,
+  "registrations": [
+    {
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
+    }
+  ],
+  "supportedTrust": ["reputation", "crypto-economic"]
+}
+```
+
+전체 필드 레퍼런스는 [에이전트 등록](/agents/register-agent#agent-registration-document)을 참조하세요.
+
+## 에이전트의 지갑 가져오기
+
+모든 Core 자산에는 **Asset Signer**라는 내장 지갑이 있습니다 — 자산의 공개 키에서 파생된 PDA입니다. 개인 키가 존재하지 않으므로 도난될 수 없습니다. 지갑은 SOL, 토큰 또는 기타 자산을 보유할 수 있습니다. `findAssetSignerPda`로 주소를 파생합니다:
+
+```typescript
+import { findAssetSignerPda } from '@metaplex-foundation/mpl-core';
+
+const assetSignerPda = findAssetSignerPda(umi, { asset: assetPublicKey });
+
+const balance = await umi.rpc.getBalance(assetSignerPda);
+console.log('Agent wallet:', assetSignerPda);
+console.log('Balance:', balance.basisPoints.toString(), 'lamports');
+```
+
+주소는 결정론적이므로 누구나 자산의 공개 키에서 주소를 파생하여 자금을 보내거나 잔액을 확인할 수 있습니다. 이 지갑에 대해 서명할 수 있는 것은 위임된 [이그제큐티브](/agents/run-an-agent)를 통한 Core의 [Execute](/smart-contracts/core/execute-asset-signing) 명령에 의한 자산 자체뿐입니다.
+
+계정 레이아웃, PDA 파생 세부사항 및 오류 코드에 대해서는 [MPL Agent Registry](/smart-contracts/mpl-agent) 스마트 컨트랙트 문서를 참조하세요.
+
+## 참고사항
+
+- Asset Signer는 PDA입니다 — 개인 키가 존재하지 않습니다. 모든 소스에서 자금을 받을 수 있지만, Core의 [Execute](/smart-contracts/core/execute-asset-signing) 명령을 통해 자산 자체만이 발신 트랜잭션에 서명할 수 있습니다.
+- `safeFetchAgentIdentityV1`은 미등록 자산에 대해 throw 대신 `null`을 반환하여 try/catch 없이 존재 여부를 안전하게 확인할 수 있습니다.
+- `findAssetSignerPda`는 지갑 주소를 결정론적으로 파생합니다. 네트워크에 관계없이 동일한 주소가 반환되므로 동일한 자산 키로 devnet과 mainnet 모두에서 사용할 수 있습니다.
+
+*Metaplex 관리 · 2026년 3월 검증 완료 · [GitHub에서 소스 보기](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/ko/agents/run-an-agent.md
+++ b/src/pages/ko/agents/run-an-agent.md
@@ -1,0 +1,216 @@
+---
+title: 에이전트 실행
+metaTitle: Solana에서 에이전트 실행 | Metaplex Agent Registry
+description: 이그제큐티브 프로필을 설정하고 실행을 위임하여 Solana에서 자율 에이전트를 실행합니다.
+keywords:
+  - run agent
+  - executive profile
+  - execution delegation
+  - Agent Tools
+  - autonomous agent
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Execution Delegation
+  - Solana
+  - Metaplex
+proficiencyLevel: Intermediate
+created: '03-11-2026'
+updated: '03-12-2026'
+---
+
+이그제큐티브 프로필을 설정하고 실행을 위임하여 Solana에서 에이전트를 실행합니다. {% .lead %}
+
+## 요약
+
+실행 위임을 통해 오프체인 이그제큐티브가 에이전트 자산을 대신하여 트랜잭션에 서명할 수 있으며, 온체인 신원과 오프체인 운영 사이의 격차를 해소합니다.
+
+- **이그제큐티브 프로필 등록** — 지갑당 1회의 온체인 설정으로 검증 가능한 운영자 신원 생성
+- **실행 위임** — 자산 소유자가 온체인 위임 레코드를 통해 에이전트를 특정 이그제큐티브에 연결
+- **위임 확인** — 위임 레코드 PDA를 파생하여 계정 존재 여부 확인
+- [등록된 에이전트](/agents/register-agent)와 `@metaplex-foundation/mpl-agent-registry` 패키지(v0.2.0+)가 **필요**
+
+## 빠른 시작
+
+1. [위임이 필요한 이유](#위임이-필요한-이유) — 위임이 해결하는 문제 이해
+2. [이그제큐티브 프로필 등록](#이그제큐티브-프로필-등록) — 지갑당 1회 설정
+3. [실행 위임](#실행-위임) — 에이전트를 이그제큐티브에 연결
+4. [위임 확인](#위임-확인) — 위임 레코드 존재 확인
+5. [전체 예제](#전체-예제) — 엔드투엔드 코드 샘플
+
+## 위임이 필요한 이유
+
+모든 Core 자산에는 내장 지갑([Asset Signer](/smart-contracts/core/execute-asset-signing))이 있습니다 — 개인 키가 없는 PDA이므로 도난될 수 없습니다. Core의 Execute 라이프사이클 훅을 통해 자산 자체만이 해당 지갑에 대해 서명할 수 있습니다.
+
+문제는 Solana가 백그라운드 작업이나 온체인 추론을 지원하지 않는다는 것입니다. 에이전트는 스스로 깨어나서 트랜잭션을 제출할 수 없습니다. 오프체인의 무언가가 이를 수행해야 합니다. 그러나 에이전트 소유자도 모든 작업을 승인하기 위해 컴퓨터 앞에 앉아 있을 필요는 없습니다.
+
+실행 위임이 이 격차를 해소합니다. 소유자는 **이그제큐티브**에게 위임합니다 — Execute 훅을 사용하여 에이전트를 대신하여 트랜잭션에 서명하는 신뢰할 수 있는 오프체인 운영자입니다. 소유자는 모든 트랜잭션을 위해 온라인 상태일 필요 없이 누가 에이전트를 실행하는지 제어합니다.
+
+## 이그제큐티브란?
+
+이그제큐티브는 에이전트 자산을 운영할 수 있는 권한을 가진 지갑을 나타내는 온체인 프로필입니다. 서비스 계정으로 생각하세요: 지갑을 이그제큐티브로 한 번 등록하면 개별 에이전트 소유자가 실행을 위임할 수 있습니다.
+
+이를 통해 **신원**(에이전트가 누구인지)과 **실행**(누가 운영하는지)이 분리됩니다. 이그제큐티브 프로필은 지갑의 공개 키에서 파생된 PDA입니다 — 지갑당 하나. 위임은 자산별로 이루어집니다: 에이전트 소유자가 에이전트를 특정 이그제큐티브에 연결하는 위임 레코드를 생성합니다. 하나의 이그제큐티브가 여러 에이전트를 실행할 수 있으며, 소유자는 에이전트의 신원을 건드리지 않고 이그제큐티브를 전환할 수 있습니다.
+
+모든 이그제큐티브 프로필은 온체인에 존재하므로 레지스트리가 검증 가능한 디렉토리 역할을 합니다. 누구나 프로필을 열거하고, 이그제큐티브가 어떤 에이전트를 운영하는지 확인하고, 위임 이력을 검사할 수 있습니다. 이는 이그제큐티브가 온체인 실적에 따라 평가되는 평판 레이어의 기반을 마련합니다.
+
+## 사전 요구사항
+
+신원 기록과 AgentIdentity 플러그인이 있는 [등록된 에이전트](/agents/register-agent)와 `@metaplex-foundation/mpl-agent-registry` 패키지(v0.2.0+)가 필요합니다.
+
+## 이그제큐티브 프로필 등록
+
+이그제큐티브가 에이전트를 실행하기 전에 프로필이 필요합니다. 이것은 지갑당 1회 설정입니다:
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { mplAgentTools } from '@metaplex-foundation/mpl-agent-registry';
+import { registerExecutiveV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentTools());
+
+await registerExecutiveV1(umi, {
+  payer: umi.payer,
+}).sendAndConfirm(umi);
+```
+
+프로필 PDA는 시드 `["executive_profile", <authority>]`에서 파생되므로 각 지갑은 하나만 가질 수 있습니다.
+
+## 실행 위임
+
+이그제큐티브 프로필이 준비되면 에이전트 자산 소유자가 실행을 위임할 수 있습니다. 이를 통해 에이전트를 이그제큐티브에 연결하는 온체인 위임 레코드가 생성됩니다:
+
+```typescript
+import { delegateExecutionV1 } from '@metaplex-foundation/mpl-agent-registry';
+import { findAgentIdentityV1Pda, findExecutiveProfileV1Pda } from '@metaplex-foundation/mpl-agent-registry';
+
+const agentIdentity = findAgentIdentityV1Pda(umi, { asset: agentAssetPublicKey });
+const executiveProfile = findExecutiveProfileV1Pda(umi, { authority: executiveAuthorityPublicKey });
+
+await delegateExecutionV1(umi, {
+  agentAsset: agentAssetPublicKey,
+  agentIdentity,
+  executiveProfile,
+}).sendAndConfirm(umi);
+```
+
+자산 소유자만 실행을 위임할 수 있습니다. 프로그램은 다음을 검증합니다:
+
+- 이그제큐티브 프로필이 존재하는지
+- 에이전트 자산이 유효한 MPL Core 자산인지
+- 에이전트가 등록된 신원을 가지고 있는지
+- 서명자가 자산 소유자인지
+
+## 매개변수
+
+### RegisterExecutiveV1
+
+| 매개변수 | 설명 |
+|-----------|-------------|
+| `payer` | 렌트 및 수수료 지불 (권한으로도 사용) |
+| `authority` | 이 이그제큐티브 프로필을 소유하는 지갑 (기본값: `payer`) |
+
+### DelegateExecutionV1
+
+| 매개변수 | 설명 |
+|-----------|-------------|
+| `agentAsset` | 등록된 에이전트의 MPL Core 자산 |
+| `agentIdentity` | 자산의 에이전트 신원 PDA |
+| `executiveProfile` | 위임할 이그제큐티브 프로필 PDA |
+| `payer` | 렌트 및 수수료 지불 (기본값: `umi.payer`) |
+| `authority` | 자산 소유자여야 함 (기본값: `payer`) |
+
+## 위임 확인
+
+위임이 존재하는지 확인하려면 위임 레코드 PDA를 파생하고 계정이 존재하는지 확인합니다:
+
+```typescript
+import {
+  findExecutiveProfileV1Pda,
+  findExecutionDelegateRecordV1Pda,
+} from '@metaplex-foundation/mpl-agent-registry';
+
+const executiveProfile = findExecutiveProfileV1Pda(umi, {
+  authority: executiveAuthorityPublicKey,
+});
+
+const delegateRecord = findExecutionDelegateRecordV1Pda(umi, {
+  executiveProfile,
+  agentAsset: agentAssetPublicKey,
+});
+
+const account = await umi.rpc.getAccount(delegateRecord);
+console.log('Delegated:', account.exists);
+```
+
+## 전체 예제
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { generateSigner } from '@metaplex-foundation/umi';
+import { create, createCollection } from '@metaplex-foundation/mpl-core';
+import { mplAgentIdentity, mplAgentTools } from '@metaplex-foundation/mpl-agent-registry';
+import {
+  registerIdentityV1,
+  registerExecutiveV1,
+  delegateExecutionV1,
+  findAgentIdentityV1Pda,
+  findExecutiveProfileV1Pda,
+} from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentIdentity())
+  .use(mplAgentTools());
+
+// 1. Create a collection
+const collection = generateSigner(umi);
+await createCollection(umi, {
+  collection,
+  name: 'Agent Collection',
+  uri: 'https://example.com/collection.json',
+}).sendAndConfirm(umi);
+
+// 2. Create an asset
+const asset = generateSigner(umi);
+await create(umi, {
+  asset,
+  name: 'My Agent',
+  uri: 'https://example.com/agent.json',
+  collection,
+}).sendAndConfirm(umi);
+
+// 3. Register identity
+await registerIdentityV1(umi, {
+  asset: asset.publicKey,
+  collection: collection.publicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+
+// 4. Register executive profile
+await registerExecutiveV1(umi, {
+  payer: umi.payer,
+}).sendAndConfirm(umi);
+
+// 5. Delegate execution
+const agentIdentity = findAgentIdentityV1Pda(umi, { asset: asset.publicKey });
+const executiveProfile = findExecutiveProfileV1Pda(umi, { authority: umi.payer.publicKey });
+
+await delegateExecutionV1(umi, {
+  agentAsset: asset.publicKey,
+  agentIdentity,
+  executiveProfile,
+}).sendAndConfirm(umi);
+```
+
+## 참고사항
+
+- 각 지갑은 하나의 이그제큐티브 프로필만 가질 수 있습니다. PDA는 `["executive_profile", <authority>]`에서 파생되므로 같은 지갑으로 `registerExecutiveV1`을 다시 호출하면 실패합니다.
+- 위임은 자산별입니다 — 소유자는 이그제큐티브가 운영할 각 에이전트에 대해 별도의 위임 레코드를 생성해야 합니다.
+- 자산 소유자만 실행을 위임할 수 있습니다. 프로그램은 온체인에서 소유권을 검증합니다.
+- 소유자는 다른 이그제큐티브 프로필로 새 위임 레코드를 생성하여 이그제큐티브를 전환할 수 있습니다.
+
+계정 레이아웃, PDA 파생 세부사항 및 오류 코드에 대해서는 [Agent Tools](/smart-contracts/mpl-agent/tools) 스마트 컨트랙트 레퍼런스를 참조하세요.
+
+*Metaplex 관리 · 2026년 3월 검증 완료 · [GitHub에서 소스 보기](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/ko/agents/skill/how-it-works.md
+++ b/src/pages/ko/agents/skill/how-it-works.md
@@ -1,0 +1,113 @@
+---
+title: 작동 방식
+metaTitle: 작동 방식 | Metaplex 스킬
+description: Metaplex 스킬의 프로그레시브 디스클로저 아키텍처를 이해합니다.
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - progressive disclosure
+  - agent skill architecture
+  - task router
+  - SKILL.md
+  - reference files
+about:
+  - Progressive disclosure
+  - Agent Skill architecture
+  - Context management
+proficiencyLevel: Intermediate
+---
+
+Metaplex Skill은 **프로그레시브 디스클로저**를 사용하여 AI 에이전트에 필요한 컨텍스트만 정확히 제공합니다. 토큰 사용량을 낮게 유지하면서 모든 Metaplex 프로그램의 포괄적인 커버리지를 제공합니다. {% .lead %}
+
+## 요약
+
+Metaplex Skill은 2계층 프로그레시브 디스클로저 아키텍처를 사용하여 토큰 사용량을 최소화하면서 AI 에이전트에 정확한 Metaplex 지식을 제공합니다.
+
+- 경량 라우터 파일(`SKILL.md`)이 작업을 특정 참조 파일에 매핑
+- 에이전트는 현재 작업과 관련된 파일만 읽음
+- 참조 파일은 CLI 명령, SDK 패턴 및 개념적 기반을 포함
+- 아키텍처는 모든 Metaplex 프로그램을 커버하면서 컨텍스트를 작게 유지
+
+## 아키텍처
+
+스킬에는 두 개의 레이어가 있습니다:
+
+1. **`SKILL.md`** — 에이전트가 먼저 읽는 경량 라우터 파일. 모든 프로그램의 개요, 도구 선택 가이드, 작업을 특정 참조 파일에 매핑하는 작업 라우터 테이블을 포함합니다.
+
+2. **참조 파일** — CLI 설정, 프로그램별 CLI 명령, SDK 패턴, 개념적 기반을 다루는 상세 파일. 에이전트는 현재 작업과 관련된 파일만 읽습니다.
+
+## 에이전트가 Metaplex Skill을 사용하는 방법
+
+에이전트에게 Metaplex 작업을 수행하도록 요청하면:
+
+1. 에이전트가 `SKILL.md`를 읽고 작업 유형을 식별
+2. 작업 라우터 테이블이 에이전트를 관련 참조 파일로 안내
+3. 에이전트가 해당 파일만 읽고 정확한 명령과 코드로 작업 실행
+
+예를 들어 *"devnet에서 Core NFT를 만들어줘"*라고 요청하면, 에이전트는 `SKILL.md`를 읽고 이것을 CLI Core 작업으로 식별한 후 `cli.md`(공통 설정)와 `cli-core.md`(Core 전용 명령)를 읽습니다.
+
+## 참조 파일
+
+스킬에는 접근 방식과 프로그램별로 구성된 참조 파일이 포함되어 있습니다:
+
+### CLI 참조
+
+이 파일들은 각 프로그램의 `mplx` CLI 명령을 다룹니다.
+
+| 파일 | 내용 |
+|------|----------|
+| `cli.md` | 공통 CLI 설정, 구성, 도구 상자 명령 |
+| `cli-core.md` | Core NFT 및 컬렉션 CLI 명령 |
+| `cli-token-metadata.md` | Token Metadata NFT/pNFT CLI 명령 |
+| `cli-bubblegum.md` | 압축 NFT(cNFT) CLI 명령 |
+| `cli-candy-machine.md` | Candy Machine 설정 및 배포 CLI 명령 |
+| `cli-genesis.md` | Genesis 토큰 출시 CLI 명령 |
+
+### SDK 참조
+
+이 파일들은 각 프로그램의 Umi 및 Kit SDK 오퍼레이션을 다룹니다.
+
+| 파일 | 내용 |
+|------|----------|
+| `sdk-umi.md` | Umi SDK 설정 및 공통 패턴 |
+| `sdk-core.md` | Umi를 통한 Core NFT 오퍼레이션 |
+| `sdk-token-metadata.md` | Umi를 통한 Token Metadata 오퍼레이션 |
+| `sdk-bubblegum.md` | Umi를 통한 압축 NFT 오퍼레이션 |
+| `sdk-genesis.md` | Umi를 통한 Genesis 토큰 출시 오퍼레이션 |
+| `sdk-token-metadata-kit.md` | Kit SDK를 통한 Token Metadata 오퍼레이션 |
+
+### 개념
+
+이 파일들은 계정 구조 및 프로그램 ID와 같은 공유 지식을 다룹니다.
+
+| 파일 | 내용 |
+|------|----------|
+| `concepts.md` | 계정 구조, PDA, 프로그램 ID |
+
+## 작업 라우터
+
+`SKILL.md`의 작업 라우터는 각 작업 유형을 에이전트가 읽어야 할 파일에 매핑합니다:
+
+| 작업 유형 | 로드되는 파일 |
+|-----------|-------------|
+| CLI 오퍼레이션(공통 설정) | `cli.md` |
+| CLI: Core NFT/컬렉션 | `cli.md` + `cli-core.md` |
+| CLI: Token Metadata NFT | `cli.md` + `cli-token-metadata.md` |
+| CLI: 압축 NFT(Bubblegum) | `cli.md` + `cli-bubblegum.md` |
+| CLI: Candy Machine(NFT 드롭) | `cli.md` + `cli-candy-machine.md` |
+| CLI: 토큰 출시(Genesis) | `cli.md` + `cli-genesis.md` |
+| CLI: 대체 가능 토큰 | `cli.md`(도구 상자 섹션) |
+| SDK 설정(Umi) | `sdk-umi.md` |
+| SDK: Core NFT | `sdk-umi.md` + `sdk-core.md` |
+| SDK: Token Metadata | `sdk-umi.md` + `sdk-token-metadata.md` |
+| SDK: 압축 NFT(Bubblegum) | `sdk-umi.md` + `sdk-bubblegum.md` |
+| SDK: Candy Machine(민팅/가드) | `sdk-umi.md` |
+| SDK: Kit을 사용한 Token Metadata | `sdk-token-metadata-kit.md` |
+| SDK: 토큰 출시(Genesis) | `sdk-umi.md` + `sdk-genesis.md` |
+| 계정 구조, PDA, 개념 | `concepts.md` |
+
+## 참고사항
+
+- 스킬은 AI 코딩 에이전트용으로 설계되었으며 사람이 읽는 문서로 렌더링되지 않을 수 있습니다
+- 참조 파일은 [Skill 리포지토리](https://github.com/metaplex-foundation/skill)와 함께 유지되며 개발자 허브와 독립적으로 업데이트될 수 있습니다
+- [Agent Skills](https://agentskills.io) 형식을 지원하지 않는 에이전트도 수동 설치를 통해 스킬을 사용할 수 있습니다

--- a/src/pages/ko/agents/skill/index.md
+++ b/src/pages/ko/agents/skill/index.md
@@ -1,0 +1,84 @@
+---
+title: Metaplex 스킬
+metaTitle: Metaplex 스킬 | 에이전트
+description: AI 코딩 에이전트에 Metaplex 프로그램, CLI 명령 및 SDK 패턴에 대한 완전한 지식을 제공하는 에이전트 스킬.
+keywords:
+  - agent skill
+  - AI coding agent
+  - Claude Code
+  - Cursor
+  - Copilot
+  - Metaplex
+  - Solana
+  - NFT
+about:
+  - Agent Skills
+  - AI-assisted development
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-23-2026'
+updated: '03-04-2026'
+---
+
+Metaplex Skill은 [Agent Skill](https://agentskills.io)입니다 — AI 코딩 에이전트에 Metaplex 프로그램, CLI 명령 및 SDK 패턴에 대한 정확하고 최신의 지식을 제공하는 지식 베이스입니다. {% .lead %}
+
+## 요약
+
+Metaplex Skill은 모든 Metaplex 프로그램, CLI 명령 및 SDK 패턴에 대한 정확한 지식을 AI 코딩 에이전트에 제공합니다.
+
+- Core, Token Metadata, Bubblegum, Candy Machine, Genesis 5개 프로그램 지원
+- CLI, Umi SDK, Kit SDK 접근 방식 지원
+- Claude Code, Cursor, Copilot, Windsurf 및 기타 호환 에이전트에서 작동
+- 프로그레시브 디스클로저를 통해 토큰 사용량을 최소화하면서 전체 커버리지 제공
+
+잘못된 API나 플래그에 의존하는 대신 AI 에이전트가 스킬을 참조하여 첫 번째 시도에서 정확한 명령과 코드를 얻을 수 있습니다.
+
+{% quick-links %}
+
+{% quick-link title="설치" icon="InboxArrowDown" href="/agents/skill/installation" description="Claude Code, Cursor, Copilot 또는 Agent Skills 형식을 지원하는 모든 에이전트에 스킬을 설치합니다." /%}
+
+{% quick-link title="작동 방식" icon="CodeBracketSquare" href="/agents/skill/how-it-works" description="프로그레시브 디스클로저가 컨텍스트를 가볍게 유지하면서 전체 커버리지를 제공하는 방법을 알아봅니다." /%}
+
+{% /quick-links %}
+
+## 지원 프로그램
+
+스킬은 5개 Metaplex 프로그램과 전체 오퍼레이션 세트를 지원합니다:
+
+| 프로그램 | 용도 | CLI | Umi SDK | Kit SDK |
+|---------|---------|-----|---------|---------|
+| **[Core](/smart-contracts/core)** | 플러그인과 로열티 강제가 있는 차세대 NFT | Yes | Yes | — |
+| **[Token Metadata](/smart-contracts/token-metadata)** | 대체 가능 토큰, NFT, pNFT, 에디션 | Yes | Yes | Yes |
+| **[Bubblegum](/smart-contracts/bubblegum-v2)** | Merkle 트리를 통한 압축 NFT | Yes | Yes | — |
+| **[Core Candy Machine](/smart-contracts/core-candy-machine)** | 설정 가능한 가드가 있는 NFT 드롭 | Yes | Yes | — |
+| **[Genesis](/smart-contracts/genesis)** | 공정한 배포를 통한 토큰 출시 | Yes | Yes | — |
+
+## 지원 오퍼레이션
+
+스킬은 Metaplex 개발의 세 가지 접근 방식에 대한 참조 자료를 제공합니다:
+
+- **CLI (`mplx`)** — 터미널에서 Metaplex 오퍼레이션 직접 실행. 자산 생성, 업로드, Candy Machine 배포, 트리 생성, 전송 등.
+- **Umi SDK** — 모든 프로그램을 커버하는 완전한 프로그래밍 접근. 소유자/컬렉션/크리에이터별 조회, DAS API 쿼리, 위임 관리, 플러그인 설정.
+- **Kit SDK** — 최소 의존성으로 `@solana/kit`을 사용한 Token Metadata 오퍼레이션.
+
+## 호환 에이전트
+
+스킬은 [Agent Skills](https://agentskills.io) 형식을 지원하는 모든 AI 코딩 에이전트에서 작동합니다:
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+- [Cursor](https://www.cursor.com/)
+- [GitHub Copilot](https://github.com/features/copilot)
+- [Codex](https://openai.com/index/codex/)
+- [Windsurf](https://windsurf.com/)
+
+## 다음 단계
+
+- **[스킬 설치](/agents/skill/installation)**로 시작
+- **[작동 방식](/agents/skill/how-it-works)**으로 아키텍처 이해
+- **[프로그램 및 오퍼레이션](/agents/skill/programs-and-operations)**에서 상세 커버리지 확인
+
+## 참고사항
+
+- 스킬은 [Agent Skills](https://agentskills.io) 형식을 지원하는 AI 코딩 에이전트가 필요합니다
+- 스킬 파일은 프로젝트에 번들된 정적 참조입니다 — 업데이트하려면 설치 명령을 다시 실행하세요
+- `npx skills add` 명령에는 Node.js와 npm/npx가 필요합니다

--- a/src/pages/ko/agents/skill/installation.md
+++ b/src/pages/ko/agents/skill/installation.md
@@ -1,0 +1,86 @@
+---
+title: 설치
+metaTitle: 설치 | Metaplex 스킬
+description: Claude Code, Cursor, Copilot 또는 모든 AI 코딩 에이전트에 Metaplex Skill을 설치합니다.
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - agent skill installation
+  - Claude Code skills
+  - Cursor skills
+  - Copilot skills
+  - npx skills add
+about:
+  - Agent Skills
+  - AI coding agent configuration
+proficiencyLevel: Beginner
+howToSteps:
+  - Run npx skills add metaplex-foundation/skill in your project directory
+  - Verify installation by asking your agent to perform a Metaplex operation
+howToTools:
+  - npx
+  - Claude Code
+  - Cursor
+  - GitHub Copilot
+---
+
+AI 코딩 에이전트가 모든 Metaplex 프로그램, CLI 명령 및 SDK 패턴에 대한 정확한 지식을 갖도록 Metaplex Skill을 설치합니다. {% .lead %}
+
+## 요약
+
+Metaplex Skill은 `npx skills` CLI 또는 에이전트의 스킬 디렉토리에 파일을 수동으로 복사하여 설치할 수 있습니다.
+
+- `npx skills add`를 통한 원커맨드 설치 (호환 에이전트 지원)
+- Claude Code용 수동 설치 지원 (프로젝트 범위 또는 글로벌)
+- Claude Code, Cursor, Copilot, Windsurf 및 기타 에이전트에서 작동
+- 에이전트에 Metaplex 오퍼레이션 수행을 요청하여 확인
+
+## skills.sh를 통해 (권장)
+
+가장 빠른 설치 방법입니다. 프로젝트 디렉토리에서 실행:
+
+```bash
+npx skills add metaplex-foundation/skill
+```
+
+이것은 Claude Code, Cursor, Copilot, Windsurf 및 [Agent Skills](https://agentskills.io) 형식을 지원하는 모든 에이전트에서 작동합니다. 명령은 스킬 파일을 프로젝트에 다운로드하여 에이전트가 자동으로 참조할 수 있게 합니다.
+
+## Claude Code 수동 설치
+
+`npx skills`를 사용하지 않으려면 스킬 파일을 수동으로 복사할 수 있습니다.
+
+### 프로젝트 범위
+
+프로젝트의 Claude 스킬 디렉토리에 스킬 파일을 복사합니다:
+
+```bash
+mkdir -p .claude/skills/metaplex
+```
+
+그런 다음 [GitHub 리포지토리](https://github.com/metaplex-foundation/skill)의 `skills/metaplex/` 내용을 `.claude/skills/metaplex/`에 복사합니다.
+
+### 글로벌
+
+모든 프로젝트에서 스킬을 사용할 수 있게 하려면:
+
+```bash
+mkdir -p ~/.claude/skills/metaplex
+```
+
+그런 다음 [GitHub 리포지토리](https://github.com/metaplex-foundation/skill)의 `skills/metaplex/` 내용을 `~/.claude/skills/metaplex/`에 복사합니다.
+
+## 설치 확인
+
+설치 후 에이전트에 Metaplex 오퍼레이션 수행을 요청합니다. 예를 들어:
+
+- *"Genesis로 토큰 출시해줘"*
+- *"devnet에서 Core NFT 컬렉션 만들어줘"*
+- *"내 트리에 압축 NFT 민팅해줘"*
+
+스킬이 올바르게 로드되면 에이전트가 잘못된 플래그나 API 없이 올바른 CLI 명령 또는 SDK 코드를 참조합니다.
+
+## 참고사항
+
+- `npx skills add` 명령에는 Node.js와 npm/npx 설치가 필요합니다
+- 수동 설치 경로는 프로젝트 범위(`.claude/skills/`)와 글로벌(`~/.claude/skills/`) 설정에 따라 다릅니다
+- 스킬 파일은 정적 참조입니다 — 최신 버전으로 업데이트하려면 설치 명령을 다시 실행하세요

--- a/src/pages/ko/agents/skill/programs-and-operations.md
+++ b/src/pages/ko/agents/skill/programs-and-operations.md
@@ -1,0 +1,150 @@
+---
+title: 프로그램 및 오퍼레이션
+metaTitle: 프로그램 및 오퍼레이션 | Metaplex 스킬
+description: Metaplex Skill이 다루는 프로그램과 오퍼레이션의 상세 분석.
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - Core
+  - Token Metadata
+  - Bubblegum
+  - Candy Machine
+  - Genesis
+  - mplx CLI
+  - Umi SDK
+  - Kit SDK
+about:
+  - Metaplex programs
+  - CLI operations
+  - SDK operations
+proficiencyLevel: Beginner
+---
+
+Metaplex Skill은 CLI, Umi SDK, Kit SDK에 걸쳐 5개 프로그램을 다룹니다. 이 페이지에서는 각 프로그램이 지원하는 기능과 사용 시기에 대한 상세 분석을 제공합니다. {% .lead %}
+
+## 요약
+
+Metaplex Skill은 CLI, Umi SDK, Kit SDK에 걸쳐 5개 Metaplex 프로그램과 사용 가능한 도구에 대한 지식을 AI 에이전트에 제공합니다.
+
+- 5개 프로그램(Core, Token Metadata, Bubblegum, Candy Machine, Genesis) 모두 CLI와 Umi SDK 지원
+- Kit SDK는 Token Metadata만 사용 가능
+- `mplx` CLI는 코드 작성 없이 대부분의 오퍼레이션 처리
+- 이 페이지에서 작업에 맞는 프로그램과 도구 접근 방식 결정
+
+## 프로그램 커버리지
+
+| 프로그램 | CLI | Umi SDK | Kit SDK |
+|---------|-----|---------|---------|
+| **Core** | Yes | Yes | — |
+| **Token Metadata** | Yes | Yes | Yes |
+| **Bubblegum** | Yes | Yes | — |
+| **Candy Machine** | Yes | Yes | — |
+| **Genesis** | Yes | Yes | — |
+
+## Core
+
+Solana의 차세대 NFT 표준. Core NFT는 Token Metadata NFT보다 상당히 저렴하며 로열티 강제, 프리즈 위임, 속성 등을 위한 플러그인 시스템을 지원합니다.
+
+**CLI** (`mplx core`): 컬렉션과 자산 생성 및 업데이트, 플러그인 관리.
+
+**Umi SDK**: 소유자/컬렉션/크리에이터별 조회, 플러그인 설정, 위임 관리를 포함한 완전한 프로그래밍 접근.
+
+## Token Metadata
+
+오리지널 Metaplex NFT 표준. 대체 가능 토큰, NFT, 프로그래밍 가능 NFT(pNFT), 에디션을 지원합니다.
+
+**CLI** (`mplx tm`): 대체 가능 토큰, NFT, pNFT, 에디션 생성. 자산 전송 및 소각.
+
+**Umi SDK**: 모든 Token Metadata 오퍼레이션에 대한 완전한 프로그래밍 접근.
+
+**Kit SDK**: 최소 의존성으로 `@solana/kit`을 사용한 Token Metadata 오퍼레이션. Umi 프레임워크를 피하고 싶을 때 유용합니다.
+
+## Bubblegum (압축 NFT)
+
+상태 압축을 위한 Merkle 트리를 사용하여 대규모로 NFT를 생성. 압축 NFT는 초기 트리 생성 후 기존 NFT의 극히 일부 비용으로 생성됩니다.
+
+**CLI** (`mplx bg`): Merkle 트리 생성, cNFT 민팅(배치 제한 ~100), 조회, 업데이트, 전송, 소각.
+
+**Umi SDK**: 완전한 프로그래밍 접근. ~100을 초과하는 배치나 DAS API 쿼리에는 SDK 사용.
+
+{% callout type="note" %}
+압축 NFT 오퍼레이션에는 DAS 지원 RPC 엔드포인트가 필요합니다. 표준 Solana RPC 엔드포인트는 cNFT 오퍼레이션에 필요한 Digital Asset Standard API를 지원하지 않습니다.
+{% /callout %}
+
+## Candy Machine
+
+설정 가능한 민팅 규칙(가드)으로 NFT 드롭 배포. 가드는 누가 민팅할 수 있는지, 언제, 얼마에, 몇 개까지 제어합니다.
+
+**CLI** (`mplx cm`): Candy Machine 설정, 아이템 삽입, 배포. 민팅에는 SDK 필요.
+
+**Umi SDK**: 민팅 오퍼레이션과 가드 설정을 포함한 완전한 프로그래밍 접근.
+
+## Genesis
+
+공정한 배포와 Raydium으로의 자동 유동성 졸업을 갖춘 토큰 출시 프로토콜.
+
+**CLI** (`mplx genesis`): 토큰 출시 생성 및 관리.
+
+**Umi SDK**: 토큰 출시 생성 및 관리를 위한 완전한 프로그래밍 접근.
+
+## CLI 기능
+
+`mplx` CLI는 코드 작성 없이 대부분의 Metaplex 오퍼레이션을 직접 처리할 수 있습니다:
+
+| 작업 | CLI 지원 |
+|------|-------------|
+| 대체 가능 토큰 생성 | Yes |
+| Core NFT/컬렉션 생성 | Yes |
+| TM NFT/pNFT 생성 | Yes |
+| TM NFT 전송 | Yes |
+| 대체 가능 토큰 전송 | Yes |
+| Core NFT 전송 | SDK만 |
+| Irys에 업로드 | Yes |
+| Candy Machine 드롭 | Yes (설정/구성/삽입 — 민팅에는 SDK 필요) |
+| 압축 NFT (cNFT) | Yes (배치 제한 ~100, 더 큰 경우 SDK 사용) |
+| SOL 잔액 확인 / 에어드롭 | Yes |
+| 소유자/컬렉션별 자산 쿼리 | SDK만 (DAS API) |
+| 토큰 출시 (Genesis) | Yes |
+
+## 결정 가이드
+
+작업에 적합한 프로그램과 도구를 선택하기 위한 가이드입니다.
+
+### NFT: Core vs Token Metadata
+
+| 선택 | 조건 |
+|--------|------|
+| **Core** | 새 NFT 프로젝트, 낮은 비용, 플러그인, 로열티 강제 |
+| **Token Metadata** | 기존 TM 컬렉션, 에디션 필요, 레거시 호환성을 위한 pNFT |
+
+### 압축 NFT를 사용할 때
+
+최소 비용으로 수천 개 이상의 NFT를 민팅할 때 **Bubblegum**을 사용합니다. 초기 비용은 Merkle 트리 생성이며, 이후 각 민팅은 트랜잭션 수수료만 발생합니다.
+
+### Candy Machine을 사용할 때
+
+민팅 규칙(허용 목록, 시작/종료 날짜, 민팅 제한, 결제 토큰 등)을 제어해야 하는 NFT 드롭에는 **Core Candy Machine**을 사용합니다.
+
+### 대체 가능 토큰
+
+대체 가능 토큰에는 항상 **Token Metadata**를 사용합니다.
+
+### 토큰 출시
+
+공정한 배포 메커니즘과 자동 Raydium 유동성 졸업을 갖춘 토큰 생성 이벤트에는 **Genesis**를 사용합니다.
+
+### CLI vs SDK
+
+| 선택 | 조건 |
+|--------|------|
+| **CLI** | 기본 선택 — 직접 실행, 코드 불필요 |
+| **Umi SDK** | 코드가 필요하거나 CLI에서 지원하지 않는 오퍼레이션 |
+| **Kit SDK** | `@solana/kit`을 사용하고 최소 의존성을 원하는 경우 (Token Metadata만) |
+
+## 참고사항
+
+- 압축 NFT(Bubblegum) 오퍼레이션에는 DAS 지원 RPC 엔드포인트가 필요합니다; 표준 Solana RPC는 Digital Asset Standard API를 지원하지 않습니다
+- Candy Machine 민팅에는 SDK가 필요합니다 — CLI는 설정, 구성, 아이템 삽입만 처리
+- Core NFT 전송은 SDK만 가능하며 CLI에서는 사용할 수 없습니다
+- 소유자 또는 컬렉션별 자산 쿼리에는 DAS API(SDK만)가 필요합니다
+- Kit SDK 지원은 Token Metadata로 제한됩니다; 다른 모든 프로그램은 Umi 사용

--- a/src/pages/ko/agents/what-is-an-agent.md
+++ b/src/pages/ko/agents/what-is-an-agent.md
@@ -1,0 +1,51 @@
+---
+title: 에이전트란?
+metaTitle: Solana의 에이전트란? | Metaplex Agent Registry
+description: Solana의 자율 에이전트는 내장 지갑과 온체인 신원 기록을 가진 MPL Core 자산입니다. 에이전트 신원, 지갑 및 실행 위임의 작동 방식을 알아봅니다.
+keywords:
+  - Solana agents
+  - autonomous agents
+  - agent identity
+  - MPL Core
+  - execution delegation
+  - Asset Signer
+about:
+  - Autonomous Agents
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '03-12-2026'
+updated: '03-12-2026'
+---
+
+Solana의 자율 에이전트는 [Metaplex Agent Registry](/smart-contracts/mpl-agent)가 관리하는 내장 지갑과 온체인 신원 기록을 가진 [MPL Core](/smart-contracts/core) 자산입니다. {% .lead %}
+
+## 요약
+
+에이전트는 온체인 신원으로 등록되어 자체 PDA 파생 지갑에 자금을 보유할 수 있는 MPL Core 자산입니다. 실행은 오프체인 운영자에게 위임되므로 소유자가 모든 트랜잭션을 승인할 필요 없이 에이전트가 자율적으로 행동할 수 있습니다.
+
+- **신원** — PDA 레코드와 `AgentIdentity` 플러그인이 검증 가능한 신원을 Core 자산에 바인딩합니다
+- **지갑** — 자산의 내장 PDA 지갑(Asset Signer)은 개인 키 노출 없이 SOL, 토큰 및 기타 자산을 보유합니다
+- **위임** — 오프체인 이그제큐티브가 Core의 Execute 라이프사이클 훅을 통해 에이전트를 대신하여 트랜잭션에 서명합니다
+- **소유자 제어** — 소유자는 에이전트의 신원이나 지갑을 변경하지 않고 언제든지 위임을 취소하거나 전환할 수 있습니다
+
+## 에이전트 자산의 작동 방식
+
+모든 [MPL Core](/smart-contracts/core) 자산에는 내장 지갑이 있습니다. 이는 자산의 공개 키에서 파생된 PDA입니다. 개인 키가 존재하지 않으므로 지갑이 도난될 수 없습니다. Core의 [Execute](/smart-contracts/core/execute-asset-signing) 라이프사이클 훅을 통해 자산 자체만이 자신의 지갑에 대해 서명할 수 있습니다.
+
+이것이 Core 자산을 자율 에이전트에 적합하게 만듭니다:
+
+- **자산이 에이전트의 신원** — [AgentIdentity](/agents/register-agent) 플러그인으로 온체인에 등록됩니다
+- **자산의 PDA 지갑이 에이전트의 자금을 보유** — 에이전트만이 독점적으로 제어하는 SOL, 토큰 및 기타 자산
+- **이그제큐티브가 에이전트를 대신하여 행동** — Solana에는 백그라운드 작업이나 온체인 추론이 없으므로 위임된 [이그제큐티브](/agents/run-an-agent)가 에이전트를 대신하여 트랜잭션에 서명합니다. 소유자는 모든 작업을 승인할 필요가 없습니다.
+
+소유자는 완전한 제어를 유지합니다. 어떤 이그제큐티브에게 위임할지 선택하고, 에이전트의 신원이나 지갑을 변경하지 않고 언제든지 위임을 취소하거나 전환할 수 있습니다.
+
+## 다음 단계
+
+- **[스킬](/agents/skill)** — AI 코딩 에이전트에 Metaplex 프로그램의 완전한 지식 제공
+- **[에이전트 등록](/agents/register-agent)** — MPL Core 자산에 신원 기록 바인딩
+- **[에이전트 데이터 읽기](/agents/run-agent)** — 등록 확인 및 온체인 에이전트 신원 검사
+- **[에이전트 실행](/agents/run-an-agent)** — 이그제큐티브 프로필 설정 및 실행 위임
+
+*Metaplex 관리 · 2026년 3월 검증 완료*

--- a/src/pages/zh/agents/index.md
+++ b/src/pages/zh/agents/index.md
@@ -1,0 +1,22 @@
+---
+title: 代理工具包
+metaTitle: 在 Solana 上创建和运行代理 | 代理注册表 | Metaplex
+description: 在 Solana 上创建、注册和运行自主代理。使用 Metaplex 代理技能和代理注册表来管理您的自主代理。
+tableOfContents: false
+keywords:
+  - Solana agents
+  - Agent Kit
+  - autonomous agents
+  - agent identity
+  - MPL Core
+  - execution delegation
+about:
+  - Autonomous Agents
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '03-11-2026'
+updated: '03-12-2026'
+---
+
+{% product-card-grid category="Agents" /%}

--- a/src/pages/zh/agents/register-agent.md
+++ b/src/pages/zh/agents/register-agent.md
@@ -1,0 +1,210 @@
+---
+title: 注册代理
+metaTitle: 在 Solana 上注册代理 | Metaplex 014 Agent Registry
+description: 通过将身份记录绑定到 MPL Core 资产，在 Metaplex 014 代理注册表上注册代理身份。
+keywords:
+  - register agent
+  - agent identity
+  - MPL Core
+  - AgentIdentity plugin
+  - ERC-8004
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Agent Registration
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-25-2026'
+updated: '03-12-2026'
+---
+
+通过将身份记录绑定到 MPL Core 资产，在 Metaplex 014 代理注册表上注册代理。{% .lead %}
+
+## 概述
+
+`registerIdentityV1` 指令将链上身份记录绑定到 MPL Core 资产，创建可发现的 PDA 并附加 Transfer、Update 和 Execute 的生命周期钩子。
+
+- 从资产公钥派生 PDA 以实现链上可发现性
+- 将带有生命周期钩子的 `AgentIdentity` 插件**附加**到 Core 资产
+- **链接**到遵循 [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) 的链下注册文档以获取代理元数据
+- **需要**现有的 MPL Core 资产和 `@metaplex-foundation/mpl-agent-registry` SDK
+
+## 快速开始
+
+1. [前提条件](#前提条件) — 获取 MPL Core 资产并安装 SDK
+2. [注册代理](#注册代理-1) — 调用 `registerIdentityV1` 绑定身份
+3. [代理注册文档](#代理注册文档) — 创建链下元数据 JSON
+4. [验证注册](#验证注册) — 确认身份已附加
+5. [完整示例](#完整示例) — 端到端代码示例
+
+## 学习内容
+本指南展示如何注册代理，包括：
+
+- 链接到 MPL Core 资产的身份记录
+- 使代理在链上可发现的 PDA（Program Derived Address）
+- 带有 Transfer、Update 和 Execute 生命周期钩子的 AgentIdentity 插件
+
+## 前提条件
+
+注册前需要一个 MPL Core 资产。如果还没有，请参阅[创建 NFT](/nfts/create-nft)。有关身份程序本身的更多信息，请参阅 [MPL Agent Registry](/smart-contracts/mpl-agent) 文档。
+
+## 注册代理
+
+注册会从资产的公钥派生创建 PDA，并附加带有 Transfer、Update 和 Execute 生命周期钩子的 `AgentIdentity` 插件。PDA 使代理可被发现——任何人都可以从资产地址派生它并检查是否存在已注册的身份。
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { mplAgentIdentity } from '@metaplex-foundation/mpl-agent-registry';
+import { registerIdentityV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentIdentity());
+
+await registerIdentityV1(umi, {
+  asset: assetPublicKey,
+  collection: collectionPublicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+```
+
+## 参数
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `asset` | 要注册的 MPL Core 资产 |
+| `collection` | 资产的集合（可选） |
+| `agentRegistrationUri` | 指向链下代理注册元数据的 URI |
+| `payer` | 支付租金和费用（默认为 `umi.payer`） |
+| `authority` | 集合权限（默认为 `payer`） |
+
+## 代理注册文档
+
+`agentRegistrationUri` 指向描述代理身份、服务和元数据的 JSON 文档。格式遵循适配 Solana 的 [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)。将 JSON（及任何相关图片）上传到 Arweave 等永久存储提供商以使其公开可访问。有关程序化上传，请参阅此[指南](/smart-contracts/mpl-hybrid/guides/create-deterministic-metadata-with-turbo)。
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "Plexpert",
+  "description": "An informational agent providing help related to Metaplex protocols and tools.",
+  "image": "https://arweave.net/agent-avatar-tx-hash",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>"
+    },
+    {
+      "name": "A2A",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/agent-card.json",
+      "version": "0.3.0"
+    },
+    {
+      "name": "MCP",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/mcp",
+      "version": "2025-06-18"
+    }
+  ],
+  "active": true,
+  "registrations": [
+    {
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
+    }
+  ],
+  "supportedTrust": [
+    "reputation",
+    "crypto-economic"
+  ]
+}
+```
+
+### 字段
+
+| 字段 | 必填 | 说明 |
+|-------|----------|-------------|
+| `type` | 是 | 模式标识符。使用 `https://eips.ethereum.org/EIPS/eip-8004#registration-v1`。 |
+| `name` | 是 | 人类可读的代理名称 |
+| `description` | 是 | 代理的自然语言描述——它做什么、如何工作以及如何交互 |
+| `image` | 是 | 头像或标志 URI |
+| `services` | 否 | 代理公开的服务端点数组（见下文） |
+| `active` | 否 | 代理当前是否处于活跃状态（`true`/`false`） |
+| `registrations` | 否 | 链接回代理身份的链上注册数组 |
+| `supportedTrust` | 否 | 代理支持的信任模型（例如 `reputation`、`crypto-economic`、`tee-attestation`） |
+
+### 服务
+
+每个服务条目描述与代理交互的方式：
+
+| 字段 | 必填 | 说明 |
+|-------|----------|-------------|
+| `name` | 是 | 服务类型——例如 `web`、`A2A`、`MCP`、`OASF`、`DID`、`email` |
+| `endpoint` | 是 | 可以访问服务的 URL 或标识符 |
+| `version` | 否 | 协议版本 |
+| `skills` | 否 | 代理通过此服务公开的技能数组 |
+| `domains` | 否 | 代理运营的域数组 |
+
+### 注册
+
+每个注册条目链接回链上身份记录：
+
+| 字段 | 必填 | 说明 |
+|-------|----------|-------------|
+| `agentId` | 是 | 代理的铸造地址 |
+| `agentRegistry` | 是 | 固定注册表标识符——使用 `solana:101:metaplex` |
+
+## 验证注册
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+
+// Check the AgentIdentity plugin
+const agentIdentity = assetData.agentIdentities?.[0];
+console.log(agentIdentity?.uri);               // your registration URI
+console.log(agentIdentity?.lifecycleChecks?.transfer);  // truthy
+console.log(agentIdentity?.lifecycleChecks?.update);    // truthy
+console.log(agentIdentity?.lifecycleChecks?.execute);   // truthy
+```
+
+## 完整示例
+
+```typescript
+import { generateSigner } from '@metaplex-foundation/umi';
+import { create, createCollection } from '@metaplex-foundation/mpl-core';
+import { registerIdentityV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+// 1. Create a collection
+const collection = generateSigner(umi);
+await createCollection(umi, {
+  collection,
+  name: 'Agent Collection',
+  uri: 'https://example.com/collection.json',
+}).sendAndConfirm(umi);
+
+// 2. Create an asset
+const asset = generateSigner(umi);
+await create(umi, {
+  asset,
+  name: 'My Agent',
+  uri: 'https://example.com/agent.json',
+  collection,
+}).sendAndConfirm(umi);
+
+// 3. Register identity
+await registerIdentityV1(umi, {
+  asset: asset.publicKey,
+  collection: collection.publicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+```
+
+## 注意事项
+
+- 注册是每个资产一次性的操作。对已注册的资产调用 `registerIdentityV1` 将失败。
+- `agentRegistrationUri` 应指向永久托管的 JSON（例如 Arweave）。如果 URI 变得不可访问，链上身份仍然存在，但客户端将无法获取代理的元数据。
+- `collection` 参数是可选的但建议使用——它在注册时启用集合级别的权限检查。
+- Transfer、Update 和 Execute 的生命周期钩子会自动附加。这些钩子允许身份插件参与批准或拒绝对资产的操作。
+
+*由 Metaplex 维护 · 2026 年 3 月验证 · [在 GitHub 上查看源码](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/zh/agents/run-agent.md
+++ b/src/pages/zh/agents/run-agent.md
@@ -1,0 +1,157 @@
+---
+title: 读取代理数据
+metaTitle: 在 Solana 上读取代理数据 | Metaplex Agent Registry
+description: 在 Solana 上验证代理注册并读取代理身份数据。
+keywords:
+  - read agent data
+  - agent identity
+  - AgentIdentity plugin
+  - Asset Signer
+  - agent wallet
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Agent Data
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-25-2026'
+updated: '03-12-2026'
+---
+
+[注册](/agents/register-agent)后在链上读取和验证代理身份数据。{% .lead %}
+
+## 概述
+
+读取代理身份数据、验证注册状态、检查 AgentIdentity 插件、获取链下注册文档以及派生代理的内置钱包地址。
+
+- 使用 `safeFetchAgentIdentityV1` **检查注册** — 对未注册资产返回 `null`
+- 直接在获取的 Core 资产上**检查 AgentIdentity 插件**的 URI 和生命周期钩子
+- 从链上 URI **获取注册文档**以读取代理元数据和服务端点
+- 使用 `findAssetSignerPda` **派生代理钱包** — 一个无私钥的 PDA 持有代理资金
+
+## 检查注册
+
+安全获取方法在身份不存在时返回 `null` 而不是抛出异常，这对于检查资产是否已注册很有用：
+
+```typescript
+import { safeFetchAgentIdentityV1, findAgentIdentityV1Pda } from '@metaplex-foundation/mpl-agent-registry';
+
+const pda = findAgentIdentityV1Pda(umi, { asset: assetPublicKey });
+const identity = await safeFetchAgentIdentityV1(umi, pda);
+
+console.log('Registered:', identity !== null);
+```
+
+## 从种子获取
+
+您也可以直接从资产的公钥获取身份，无需手动派生 PDA：
+
+```typescript
+import { fetchAgentIdentityV1FromSeeds } from '@metaplex-foundation/mpl-agent-registry';
+
+const identity = await fetchAgentIdentityV1FromSeeds(umi, {
+  asset: assetPublicKey,
+});
+```
+
+## 验证 AgentIdentity 插件
+
+注册会将 `AgentIdentity` 插件附加到 Core 资产。您可以直接从获取的资产中读取它来检查注册 URI 和生命周期钩子：
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+
+const agentIdentity = assetData.agentIdentities?.[0];
+console.log(agentIdentity?.uri);               // registration URI
+console.log(agentIdentity?.lifecycleChecks?.transfer);  // truthy
+console.log(agentIdentity?.lifecycleChecks?.update);    // truthy
+console.log(agentIdentity?.lifecycleChecks?.execute);   // truthy
+```
+
+## 读取注册文档
+
+`AgentIdentity` 插件上的 `uri` 指向一个包含代理完整配置文件（名称、描述、服务端点等）的链下 JSON 文档。像其他 URI 一样获取它：
+
+```typescript
+import { fetchAsset } from '@metaplex-foundation/mpl-core';
+
+const assetData = await fetchAsset(umi, assetPublicKey);
+const agentIdentity = assetData.agentIdentities?.[0];
+
+if (agentIdentity?.uri) {
+  const response = await fetch(agentIdentity.uri);
+  const registration = await response.json();
+
+  console.log(registration.name);          // "Plexpert"
+  console.log(registration.description);   // "An informational agent..."
+  console.log(registration.active);        // true
+
+  for (const service of registration.services) {
+    console.log(service.name);             // "web", "A2A", "MCP", etc.
+    console.log(service.endpoint);         // service URL
+    console.log(service.version);          // protocol version (if set)
+  }
+}
+```
+
+该文档遵循 [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) 代理注册标准。典型示例如下：
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "An informational agent providing help related to Metaplex protocols and tools.",
+  "description": "An autonomous agent that executes DeFi strategies on Solana.",
+  "image": "https://arweave.net/agent-avatar-tx-hash",
+  "services": [
+    {
+      "name": "web",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>"
+    },
+    {
+      "name": "A2A",
+      "endpoint": "https://metaplex.com/agent/<ASSET_PUBKEY>/agent-card.json",
+      "version": "0.3.0"
+    }
+  ],
+  "active": true,
+  "registrations": [
+    {
+      "agentId": "<MINT_ADDRESS>",
+      "agentRegistry": "solana:101:metaplex"
+    }
+  ],
+  "supportedTrust": ["reputation", "crypto-economic"]
+}
+```
+
+完整字段参考请参阅[注册代理](/agents/register-agent#agent-registration-document)。
+
+## 获取代理钱包
+
+每个 Core 资产都有一个称为 **Asset Signer** 的内置钱包——从资产公钥派生的 PDA。不存在私钥，因此无法被盗。钱包可以持有 SOL、代币或任何其他资产。使用 `findAssetSignerPda` 派生地址：
+
+```typescript
+import { findAssetSignerPda } from '@metaplex-foundation/mpl-core';
+
+const assetSignerPda = findAssetSignerPda(umi, { asset: assetPublicKey });
+
+const balance = await umi.rpc.getBalance(assetSignerPda);
+console.log('Agent wallet:', assetSignerPda);
+console.log('Balance:', balance.basisPoints.toString(), 'lamports');
+```
+
+地址是确定性的，因此任何人都可以从资产的公钥派生它来发送资金或检查余额。只有资产本身才能通过委托的[执行者](/agents/run-an-agent)经由 Core 的 [Execute](/smart-contracts/core/execute-asset-signing) 指令为此钱包签名。
+
+有关账户布局、PDA 派生详情和错误代码，请参阅 [MPL Agent Registry](/smart-contracts/mpl-agent) 智能合约文档。
+
+## 注意事项
+
+- Asset Signer 是一个 PDA——不存在私钥。它可以从任何来源接收资金，但只有资产本身才能通过 Core 的 [Execute](/smart-contracts/core/execute-asset-signing) 指令签署发出的交易。
+- `safeFetchAgentIdentityV1` 对未注册资产返回 `null` 而不是抛出异常，使其可以安全地用于无需 try/catch 的存在性检查。
+- `findAssetSignerPda` 确定性地派生钱包地址。无论网络如何都返回相同的地址，因此您可以使用相同的资产密钥在 devnet 和 mainnet 上使用它。
+
+*由 Metaplex 维护 · 2026 年 3 月验证 · [在 GitHub 上查看源码](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/zh/agents/run-an-agent.md
+++ b/src/pages/zh/agents/run-an-agent.md
@@ -1,0 +1,216 @@
+---
+title: 运行代理
+metaTitle: 在 Solana 上运行代理 | Metaplex Agent Registry
+description: 设置执行者配置文件并委托执行，以在 Solana 上运行自主代理。
+keywords:
+  - run agent
+  - executive profile
+  - execution delegation
+  - Agent Tools
+  - autonomous agent
+programmingLanguage:
+  - JavaScript
+  - TypeScript
+about:
+  - Execution Delegation
+  - Solana
+  - Metaplex
+proficiencyLevel: Intermediate
+created: '03-11-2026'
+updated: '03-12-2026'
+---
+
+设置执行者配置文件并委托执行，以在 Solana 上运行代理。{% .lead %}
+
+## 概述
+
+执行委托允许链下执行者代表代理资产签署交易，弥合链上身份与链下操作之间的差距。
+
+- **注册执行者配置文件** — 每个钱包一次性的链上设置，创建可验证的运营者身份
+- **委托执行** — 资产所有者通过链上委托记录将其代理链接到特定执行者
+- **验证委托** — 派生委托记录 PDA 并检查账户是否存在
+- **需要**一个[已注册的代理](/agents/register-agent)和 `@metaplex-foundation/mpl-agent-registry` 包（v0.2.0+）
+
+## 快速开始
+
+1. [为什么需要委托](#为什么需要委托) — 了解委托解决的问题
+2. [注册执行者配置文件](#注册执行者配置文件) — 每个钱包一次性设置
+3. [委托执行](#委托执行) — 将代理链接到执行者
+4. [验证委托](#验证委托) — 确认委托记录存在
+5. [完整示例](#完整示例) — 端到端代码示例
+
+## 为什么需要委托
+
+每个 Core 资产都有一个内置钱包（[Asset Signer](/smart-contracts/core/execute-asset-signing)）——一个没有私钥的 PDA，这意味着它不会被盗。只有资产本身才能通过 Core 的 Execute 生命周期钩子为该钱包签名。
+
+问题在于 Solana 不支持后台任务或链上推理。代理无法自行唤醒并提交交易。必须由链下的某个东西来执行。但代理所有者也不应该必须坐在电脑前批准每个操作。
+
+执行委托弥合了这一差距。所有者委托给一个**执行者**——一个受信任的链下运营者，使用 Execute 钩子代表代理签署交易。所有者控制谁来运行他们的代理，而无需为每笔交易保持在线。
+
+## 什么是执行者？
+
+执行者是一个链上配置文件，代表被授权运营代理资产的钱包。可以将其视为服务账户：您将钱包注册为执行者一次，然后各个代理所有者可以将执行委托给它。
+
+这将**身份**（代理是谁）与**执行**（谁来运营）分离。执行者配置文件是从钱包公钥派生的 PDA——每个钱包一个。委托是按资产进行的：代理所有者创建一个将其代理链接到特定执行者的委托记录。一个执行者可以运行许多代理，所有者可以在不触及代理身份的情况下切换执行者。
+
+每个执行者配置文件都存在于链上，因此注册表充当可验证的目录。任何人都可以枚举配置文件，查看执行者运营哪些代理，并检查委托历史。这为执行者根据其链上记录进行评级的声誉层奠定了基础。
+
+## 前提条件
+
+您需要一个具有身份记录和 AgentIdentity 插件的[已注册代理](/agents/register-agent)，以及 `@metaplex-foundation/mpl-agent-registry` 包（v0.2.0+）。
+
+## 注册执行者配置文件
+
+在执行者运行任何代理之前，它需要一个配置文件。这是每个钱包一次性的设置：
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { mplAgentTools } from '@metaplex-foundation/mpl-agent-registry';
+import { registerExecutiveV1 } from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentTools());
+
+await registerExecutiveV1(umi, {
+  payer: umi.payer,
+}).sendAndConfirm(umi);
+```
+
+配置文件 PDA 从种子 `["executive_profile", <authority>]` 派生，因此每个钱包只能有一个。
+
+## 委托执行
+
+执行者配置文件就位后，代理资产所有者可以将执行委托给它。这将在链上创建一个将代理链接到执行者的委托记录：
+
+```typescript
+import { delegateExecutionV1 } from '@metaplex-foundation/mpl-agent-registry';
+import { findAgentIdentityV1Pda, findExecutiveProfileV1Pda } from '@metaplex-foundation/mpl-agent-registry';
+
+const agentIdentity = findAgentIdentityV1Pda(umi, { asset: agentAssetPublicKey });
+const executiveProfile = findExecutiveProfileV1Pda(umi, { authority: executiveAuthorityPublicKey });
+
+await delegateExecutionV1(umi, {
+  agentAsset: agentAssetPublicKey,
+  agentIdentity,
+  executiveProfile,
+}).sendAndConfirm(umi);
+```
+
+只有资产所有者可以委托执行。程序验证：
+
+- 执行者配置文件存在
+- 代理资产是有效的 MPL Core 资产
+- 代理具有已注册的身份
+- 签名者是资产所有者
+
+## 参数
+
+### RegisterExecutiveV1
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `payer` | 支付租金和费用（也用作权限） |
+| `authority` | 拥有此执行者配置文件的钱包（默认为 `payer`） |
+
+### DelegateExecutionV1
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `agentAsset` | 已注册代理的 MPL Core 资产 |
+| `agentIdentity` | 资产的代理身份 PDA |
+| `executiveProfile` | 要委托的执行者配置文件 PDA |
+| `payer` | 支付租金和费用（默认为 `umi.payer`） |
+| `authority` | 必须是资产所有者（默认为 `payer`） |
+
+## 验证委托
+
+要检查委托是否存在，派生委托记录 PDA 并查看账户是否存在：
+
+```typescript
+import {
+  findExecutiveProfileV1Pda,
+  findExecutionDelegateRecordV1Pda,
+} from '@metaplex-foundation/mpl-agent-registry';
+
+const executiveProfile = findExecutiveProfileV1Pda(umi, {
+  authority: executiveAuthorityPublicKey,
+});
+
+const delegateRecord = findExecutionDelegateRecordV1Pda(umi, {
+  executiveProfile,
+  agentAsset: agentAssetPublicKey,
+});
+
+const account = await umi.rpc.getAccount(delegateRecord);
+console.log('Delegated:', account.exists);
+```
+
+## 完整示例
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { generateSigner } from '@metaplex-foundation/umi';
+import { create, createCollection } from '@metaplex-foundation/mpl-core';
+import { mplAgentIdentity, mplAgentTools } from '@metaplex-foundation/mpl-agent-registry';
+import {
+  registerIdentityV1,
+  registerExecutiveV1,
+  delegateExecutionV1,
+  findAgentIdentityV1Pda,
+  findExecutiveProfileV1Pda,
+} from '@metaplex-foundation/mpl-agent-registry';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com')
+  .use(mplAgentIdentity())
+  .use(mplAgentTools());
+
+// 1. Create a collection
+const collection = generateSigner(umi);
+await createCollection(umi, {
+  collection,
+  name: 'Agent Collection',
+  uri: 'https://example.com/collection.json',
+}).sendAndConfirm(umi);
+
+// 2. Create an asset
+const asset = generateSigner(umi);
+await create(umi, {
+  asset,
+  name: 'My Agent',
+  uri: 'https://example.com/agent.json',
+  collection,
+}).sendAndConfirm(umi);
+
+// 3. Register identity
+await registerIdentityV1(umi, {
+  asset: asset.publicKey,
+  collection: collection.publicKey,
+  agentRegistrationUri: 'https://example.com/agent-registration.json',
+}).sendAndConfirm(umi);
+
+// 4. Register executive profile
+await registerExecutiveV1(umi, {
+  payer: umi.payer,
+}).sendAndConfirm(umi);
+
+// 5. Delegate execution
+const agentIdentity = findAgentIdentityV1Pda(umi, { asset: asset.publicKey });
+const executiveProfile = findExecutiveProfileV1Pda(umi, { authority: umi.payer.publicKey });
+
+await delegateExecutionV1(umi, {
+  agentAsset: asset.publicKey,
+  agentIdentity,
+  executiveProfile,
+}).sendAndConfirm(umi);
+```
+
+## 注意事项
+
+- 每个钱包只能有一个执行者配置文件。PDA 从 `["executive_profile", <authority>]` 派生，因此使用同一钱包再次调用 `registerExecutiveV1` 将失败。
+- 委托是按资产进行的——所有者必须为每个要让执行者运营的代理创建单独的委托记录。
+- 只有资产所有者可以委托执行。程序在链上验证所有权。
+- 所有者可以通过使用不同的执行者配置文件创建新的委托记录来切换执行者。
+
+有关账户布局、PDA 派生详情和错误代码，请参阅 [Agent Tools](/smart-contracts/mpl-agent/tools) 智能合约参考。
+
+*由 Metaplex 维护 · 2026 年 3 月验证 · [在 GitHub 上查看源码](https://github.com/metaplex-foundation/mpl-agent)*

--- a/src/pages/zh/agents/skill/how-it-works.md
+++ b/src/pages/zh/agents/skill/how-it-works.md
@@ -1,0 +1,113 @@
+---
+title: 工作原理
+metaTitle: 工作原理 | Metaplex 技能
+description: 了解 Metaplex 技能的渐进式披露架构。
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - progressive disclosure
+  - agent skill architecture
+  - task router
+  - SKILL.md
+  - reference files
+about:
+  - Progressive disclosure
+  - Agent Skill architecture
+  - Context management
+proficiencyLevel: Intermediate
+---
+
+Metaplex Skill 使用**渐进式披露**为 AI 代理提供恰好需要的上下文——不多不少。这在保持低令牌使用量的同时提供所有 Metaplex 程序的全面覆盖。{% .lead %}
+
+## 概述
+
+Metaplex Skill 使用两层渐进式披露架构，在最小化令牌使用量的同时为 AI 代理提供准确的 Metaplex 知识。
+
+- 轻量级路由文件（`SKILL.md`）将任务映射到特定参考文件
+- 代理仅读取与当前任务相关的文件
+- 参考文件涵盖 CLI 命令、SDK 模式和概念基础
+- 架构在覆盖所有 Metaplex 程序的同时保持上下文较小
+
+## 架构
+
+Skill 有两个层次：
+
+1. **`SKILL.md`** — 代理首先读取的轻量级路由文件。包含所有程序的概述、工具选择指南以及将任务映射到特定参考文件的任务路由表。
+
+2. **参考文件** — 涵盖 CLI 设置、程序特定 CLI 命令、SDK 模式和概念基础的详细文件。代理仅读取与当前任务相关的文件。
+
+## 代理如何使用 Metaplex Skill
+
+当您要求代理执行 Metaplex 任务时：
+
+1. 代理读取 `SKILL.md` 并识别任务类型
+2. 任务路由表将代理引导到相关参考文件
+3. 代理仅读取那些文件并使用准确的命令和代码执行任务
+
+例如，如果您请求*"在 devnet 上创建一个 Core NFT"*，代理读取 `SKILL.md`，将其识别为 CLI Core 任务，然后读取 `cli.md`（共享设置）和 `cli-core.md`（Core 特定命令）。
+
+## 参考文件
+
+Skill 包含按方法和程序组织的参考文件：
+
+### CLI 参考
+
+这些文件涵盖每个程序的 `mplx` CLI 命令。
+
+| 文件 | 内容 |
+|------|----------|
+| `cli.md` | 共享 CLI 设置、配置、工具箱命令 |
+| `cli-core.md` | Core NFT 和集合 CLI 命令 |
+| `cli-token-metadata.md` | Token Metadata NFT/pNFT CLI 命令 |
+| `cli-bubblegum.md` | 压缩 NFT (cNFT) CLI 命令 |
+| `cli-candy-machine.md` | Candy Machine 设置和部署 CLI 命令 |
+| `cli-genesis.md` | Genesis 代币发行 CLI 命令 |
+
+### SDK 参考
+
+这些文件涵盖每个程序的 Umi 和 Kit SDK 操作。
+
+| 文件 | 内容 |
+|------|----------|
+| `sdk-umi.md` | Umi SDK 设置和常见模式 |
+| `sdk-core.md` | 通过 Umi 的 Core NFT 操作 |
+| `sdk-token-metadata.md` | 通过 Umi 的 Token Metadata 操作 |
+| `sdk-bubblegum.md` | 通过 Umi 的压缩 NFT 操作 |
+| `sdk-genesis.md` | 通过 Umi 的 Genesis 代币发行操作 |
+| `sdk-token-metadata-kit.md` | 通过 Kit SDK 的 Token Metadata 操作 |
+
+### 概念
+
+这些文件涵盖账户结构和程序 ID 等共享知识。
+
+| 文件 | 内容 |
+|------|----------|
+| `concepts.md` | 账户结构、PDA、程序 ID |
+
+## 任务路由器
+
+`SKILL.md` 中的任务路由器将每种任务类型映射到代理应读取的文件：
+
+| 任务类型 | 加载的文件 |
+|-----------|-------------|
+| CLI 操作（共享设置） | `cli.md` |
+| CLI: Core NFT/集合 | `cli.md` + `cli-core.md` |
+| CLI: Token Metadata NFT | `cli.md` + `cli-token-metadata.md` |
+| CLI: 压缩 NFT (Bubblegum) | `cli.md` + `cli-bubblegum.md` |
+| CLI: Candy Machine (NFT 投放) | `cli.md` + `cli-candy-machine.md` |
+| CLI: 代币发行 (Genesis) | `cli.md` + `cli-genesis.md` |
+| CLI: 同质化代币 | `cli.md`（工具箱部分） |
+| SDK 设置 (Umi) | `sdk-umi.md` |
+| SDK: Core NFT | `sdk-umi.md` + `sdk-core.md` |
+| SDK: Token Metadata | `sdk-umi.md` + `sdk-token-metadata.md` |
+| SDK: 压缩 NFT (Bubblegum) | `sdk-umi.md` + `sdk-bubblegum.md` |
+| SDK: Candy Machine（铸造/守卫） | `sdk-umi.md` |
+| SDK: 使用 Kit 的 Token Metadata | `sdk-token-metadata-kit.md` |
+| SDK: 代币发行 (Genesis) | `sdk-umi.md` + `sdk-genesis.md` |
+| 账户结构、PDA、概念 | `concepts.md` |
+
+## 注意事项
+
+- Skill 是为 AI 编码代理设计的，可能不会渲染为人类可读的文档
+- 参考文件与 [Skill 仓库](https://github.com/metaplex-foundation/skill)一起维护，可能独立于开发者中心更新
+- 不支持 [Agent Skills](https://agentskills.io) 格式的代理仍可通过手动安装使用 Skill

--- a/src/pages/zh/agents/skill/index.md
+++ b/src/pages/zh/agents/skill/index.md
@@ -1,0 +1,84 @@
+---
+title: Metaplex 技能
+metaTitle: Metaplex 技能 | 代理
+description: 为 AI 编码代理提供 Metaplex 程序、CLI 命令和 SDK 模式完整知识的代理技能。
+keywords:
+  - agent skill
+  - AI coding agent
+  - Claude Code
+  - Cursor
+  - Copilot
+  - Metaplex
+  - Solana
+  - NFT
+about:
+  - Agent Skills
+  - AI-assisted development
+  - Metaplex
+proficiencyLevel: Beginner
+created: '02-23-2026'
+updated: '03-04-2026'
+---
+
+Metaplex Skill 是一个 [Agent Skill](https://agentskills.io)——一个为 AI 编码代理提供 Metaplex 程序、CLI 命令和 SDK 模式准确、最新知识的知识库。{% .lead %}
+
+## 概述
+
+Metaplex Skill 为 AI 编码代理提供所有 Metaplex 程序、CLI 命令和 SDK 模式的准确知识。
+
+- 覆盖五个程序：Core、Token Metadata、Bubblegum、Candy Machine 和 Genesis
+- 支持 CLI、Umi SDK 和 Kit SDK 方法
+- 适用于 Claude Code、Cursor、Copilot、Windsurf 及其他兼容代理
+- 使用渐进式披露最小化令牌使用量同时提供完整覆盖
+
+您的 AI 代理可以参考 Skill 在第一次尝试时获取准确的命令和代码，而不是依赖错误的 API 或标志。
+
+{% quick-links %}
+
+{% quick-link title="安装" icon="InboxArrowDown" href="/agents/skill/installation" description="在 Claude Code、Cursor、Copilot 或任何支持 Agent Skills 格式的代理中安装技能。" /%}
+
+{% quick-link title="工作原理" icon="CodeBracketSquare" href="/agents/skill/how-it-works" description="了解渐进式披露如何保持上下文轻量同时提供完整覆盖。" /%}
+
+{% /quick-links %}
+
+## 覆盖的程序
+
+Skill 覆盖五个 Metaplex 程序及其完整操作集：
+
+| 程序 | 用途 | CLI | Umi SDK | Kit SDK |
+|---------|---------|-----|---------|---------|
+| **[Core](/smart-contracts/core)** | 带插件和版税强制的下一代 NFT | Yes | Yes | — |
+| **[Token Metadata](/smart-contracts/token-metadata)** | 同质化代币、NFT、pNFT、版本 | Yes | Yes | Yes |
+| **[Bubblegum](/smart-contracts/bubblegum-v2)** | 通过 Merkle 树的压缩 NFT | Yes | Yes | — |
+| **[Core Candy Machine](/smart-contracts/core-candy-machine)** | 带可配置守卫的 NFT 投放 | Yes | Yes | — |
+| **[Genesis](/smart-contracts/genesis)** | 公平分发的代币发行 | Yes | Yes | — |
+
+## 支持的操作
+
+Skill 为 Metaplex 开发的三种方法提供参考材料：
+
+- **CLI (`mplx`)** — 从终端直接执行 Metaplex 操作。资产创建、上传、Candy Machine 部署、树创建、转移等。
+- **Umi SDK** — 覆盖所有程序的完整编程访问。按所有者/集合/创建者查询、DAS API 查询、委托管理和插件配置。
+- **Kit SDK** — 使用 `@solana/kit` 以最少依赖进行 Token Metadata 操作。
+
+## 兼容的代理
+
+Skill 适用于任何支持 [Agent Skills](https://agentskills.io) 格式的 AI 编码代理：
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+- [Cursor](https://www.cursor.com/)
+- [GitHub Copilot](https://github.com/features/copilot)
+- [Codex](https://openai.com/index/codex/)
+- [Windsurf](https://windsurf.com/)
+
+## 下一步
+
+- **[安装技能](/agents/skill/installation)** 开始使用
+- **[工作原理](/agents/skill/how-it-works)** 了解架构
+- **[程序和操作](/agents/skill/programs-and-operations)** 查看详细覆盖
+
+## 注意事项
+
+- Skill 需要支持 [Agent Skills](https://agentskills.io) 格式的 AI 编码代理
+- Skill 文件是捆绑到项目中的静态引用——重新运行安装命令以更新
+- `npx skills add` 命令需要 Node.js 和 npm/npx

--- a/src/pages/zh/agents/skill/installation.md
+++ b/src/pages/zh/agents/skill/installation.md
@@ -1,0 +1,86 @@
+---
+title: 安装
+metaTitle: 安装 | Metaplex 技能
+description: 在 Claude Code、Cursor、Copilot 或任何 AI 编码代理中安装 Metaplex Skill。
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - agent skill installation
+  - Claude Code skills
+  - Cursor skills
+  - Copilot skills
+  - npx skills add
+about:
+  - Agent Skills
+  - AI coding agent configuration
+proficiencyLevel: Beginner
+howToSteps:
+  - Run npx skills add metaplex-foundation/skill in your project directory
+  - Verify installation by asking your agent to perform a Metaplex operation
+howToTools:
+  - npx
+  - Claude Code
+  - Cursor
+  - GitHub Copilot
+---
+
+安装 Metaplex Skill，让您的 AI 编码代理拥有所有 Metaplex 程序、CLI 命令和 SDK 模式的准确知识。{% .lead %}
+
+## 概述
+
+Metaplex Skill 可以通过 `npx skills` CLI 或手动将文件复制到代理的技能目录来安装。
+
+- 通过 `npx skills add` 一键安装（兼容所有支持的代理）
+- 支持 Claude Code 手动安装（项目范围或全局）
+- 适用于 Claude Code、Cursor、Copilot、Windsurf 及其他代理
+- 通过要求代理执行任何 Metaplex 操作来验证
+
+## 通过 skills.sh（推荐）
+
+最快的安装方式。在项目目录中运行：
+
+```bash
+npx skills add metaplex-foundation/skill
+```
+
+这适用于 Claude Code、Cursor、Copilot、Windsurf 以及任何支持 [Agent Skills](https://agentskills.io) 格式的代理。该命令将 Skill 文件下载到您的项目中，以便代理可以自动引用。
+
+## Claude Code 手动安装
+
+如果您不想使用 `npx skills`，可以手动复制 Skill 文件。
+
+### 项目范围
+
+将 Skill 文件复制到项目的 Claude 技能目录：
+
+```bash
+mkdir -p .claude/skills/metaplex
+```
+
+然后将 [GitHub 仓库](https://github.com/metaplex-foundation/skill) 中 `skills/metaplex/` 的内容复制到 `.claude/skills/metaplex/`。
+
+### 全局
+
+要使 Skill 在所有项目中可用：
+
+```bash
+mkdir -p ~/.claude/skills/metaplex
+```
+
+然后将 [GitHub 仓库](https://github.com/metaplex-foundation/skill) 中 `skills/metaplex/` 的内容复制到 `~/.claude/skills/metaplex/`。
+
+## 验证安装
+
+安装后，要求代理执行 Metaplex 操作。例如：
+
+- *"用 Genesis 发行代币"*
+- *"在 devnet 上创建 Core NFT 集合"*
+- *"向我的树铸造压缩 NFT"*
+
+如果 Skill 正确加载，代理将引用正确的 CLI 命令或 SDK 代码，而不会产生错误的标志或 API。
+
+## 注意事项
+
+- `npx skills add` 命令需要安装 Node.js 和 npm/npx
+- 手动安装路径在项目范围（`.claude/skills/`）和全局（`~/.claude/skills/`）设置之间有所不同
+- Skill 文件是静态引用——重新运行安装命令以获取最新版本

--- a/src/pages/zh/agents/skill/programs-and-operations.md
+++ b/src/pages/zh/agents/skill/programs-and-operations.md
@@ -1,0 +1,150 @@
+---
+title: 程序和操作
+metaTitle: 程序和操作 | Metaplex 技能
+description: Metaplex Skill 覆盖的程序和操作的详细分析。
+created: '02-23-2026'
+updated: '03-04-2026'
+keywords:
+  - Core
+  - Token Metadata
+  - Bubblegum
+  - Candy Machine
+  - Genesis
+  - mplx CLI
+  - Umi SDK
+  - Kit SDK
+about:
+  - Metaplex programs
+  - CLI operations
+  - SDK operations
+proficiencyLevel: Beginner
+---
+
+Metaplex Skill 覆盖 CLI、Umi SDK 和 Kit SDK 中的五个程序。本页提供每个程序支持的功能以及使用时机的详细分析。{% .lead %}
+
+## 概述
+
+Metaplex Skill 为 AI 代理提供关于五个 Metaplex 程序及其在 CLI、Umi SDK 和 Kit SDK 中可用工具的知识。
+
+- 所有五个程序（Core、Token Metadata、Bubblegum、Candy Machine、Genesis）都支持 CLI 和 Umi SDK
+- Kit SDK 仅适用于 Token Metadata
+- `mplx` CLI 无需编写代码即可处理大多数操作
+- 使用本页确定适合您任务的程序和工具方法
+
+## 程序覆盖
+
+| 程序 | CLI | Umi SDK | Kit SDK |
+|---------|-----|---------|---------|
+| **Core** | Yes | Yes | — |
+| **Token Metadata** | Yes | Yes | Yes |
+| **Bubblegum** | Yes | Yes | — |
+| **Candy Machine** | Yes | Yes | — |
+| **Genesis** | Yes | Yes | — |
+
+## Core
+
+Solana 上的下一代 NFT 标准。Core NFT 比 Token Metadata NFT 便宜得多，支持版税强制、冻结委托、属性等插件系统。
+
+**CLI** (`mplx core`)：创建和更新集合与资产，管理插件。
+
+**Umi SDK**：完整的编程访问，包括按所有者/集合/创建者查询、插件配置和委托管理。
+
+## Token Metadata
+
+原始的 Metaplex NFT 标准。支持同质化代币、NFT、可编程 NFT (pNFT) 和版本。
+
+**CLI** (`mplx tm`)：创建同质化代币、NFT、pNFT 和版本。转移和销毁资产。
+
+**Umi SDK**：对所有 Token Metadata 操作的完整编程访问。
+
+**Kit SDK**：使用 `@solana/kit` 以最少依赖进行 Token Metadata 操作。当您想避免 Umi 框架时很有用。
+
+## Bubblegum（压缩 NFT）
+
+使用 Merkle 树进行状态压缩，大规模创建 NFT。压缩 NFT 在初始树创建后仅需传统 NFT 的一小部分成本。
+
+**CLI** (`mplx bg`)：创建 Merkle 树，铸造 cNFT（批量限制约 100），查询、更新、转移和销毁。
+
+**Umi SDK**：完整的编程访问。对于超过约 100 的批量或 DAS API 查询，使用 SDK。
+
+{% callout type="note" %}
+压缩 NFT 操作需要支持 DAS 的 RPC 端点。标准 Solana RPC 端点不支持 cNFT 操作所需的 Digital Asset Standard API。
+{% /callout %}
+
+## Candy Machine
+
+使用可配置的铸造规则（守卫）部署 NFT 投放。守卫控制谁可以铸造、何时、以什么价格以及多少个。
+
+**CLI** (`mplx cm`)：设置 Candy Machine 配置、插入项目和部署。铸造需要 SDK。
+
+**Umi SDK**：包括铸造操作和守卫配置的完整编程访问。
+
+## Genesis
+
+具有公平分发和自动向 Raydium 流动性毕业的代币发行协议。
+
+**CLI** (`mplx genesis`)：创建和管理代币发行。
+
+**Umi SDK**：用于创建和管理代币发行的完整编程访问。
+
+## CLI 功能
+
+`mplx` CLI 无需编写代码即可直接处理大多数 Metaplex 操作：
+
+| 任务 | CLI 支持 |
+|------|-------------|
+| 创建同质化代币 | Yes |
+| 创建 Core NFT/集合 | Yes |
+| 创建 TM NFT/pNFT | Yes |
+| 转移 TM NFT | Yes |
+| 转移同质化代币 | Yes |
+| 转移 Core NFT | 仅 SDK |
+| 上传到 Irys | Yes |
+| Candy Machine 投放 | Yes（设置/配置/插入——铸造需要 SDK） |
+| 压缩 NFT (cNFT) | Yes（批量限制约 100，更大批量使用 SDK） |
+| 检查 SOL 余额/空投 | Yes |
+| 按所有者/集合查询资产 | 仅 SDK (DAS API) |
+| 代币发行 (Genesis) | Yes |
+
+## 选择指南
+
+使用以下指导为您的任务选择合适的程序和工具。
+
+### NFT: Core vs Token Metadata
+
+| 选择 | 条件 |
+|--------|------|
+| **Core** | 新 NFT 项目、更低成本、插件、版税强制 |
+| **Token Metadata** | 现有 TM 集合、需要版本、用于遗留兼容性的 pNFT |
+
+### 何时使用压缩 NFT
+
+以最低成本铸造数千个或更多 NFT 时使用 **Bubblegum**。前期成本是 Merkle 树创建；之后每次铸造仅需交易费用。
+
+### 何时使用 Candy Machine
+
+需要控制铸造规则（白名单、开始/结束日期、铸造限制、支付代币等）的 NFT 投放使用 **Core Candy Machine**。
+
+### 同质化代币
+
+同质化代币始终使用 **Token Metadata**。
+
+### 代币发行
+
+具有公平分发机制和自动 Raydium 流动性毕业的代币生成事件使用 **Genesis**。
+
+### CLI vs SDK
+
+| 选择 | 条件 |
+|--------|------|
+| **CLI** | 默认选择——直接执行，无需代码 |
+| **Umi SDK** | 需要代码，或操作不被 CLI 支持 |
+| **Kit SDK** | 特别使用 `@solana/kit` 且需要最少依赖（仅 Token Metadata） |
+
+## 注意事项
+
+- 压缩 NFT (Bubblegum) 操作需要支持 DAS 的 RPC 端点；标准 Solana RPC 不支持 Digital Asset Standard API
+- Candy Machine 铸造需要 SDK——CLI 仅处理设置、配置和项目插入
+- Core NFT 转移仅限 SDK，CLI 中不可用
+- 按所有者或集合查询资产需要 DAS API（仅 SDK）
+- Kit SDK 支持仅限于 Token Metadata；所有其他程序使用 Umi

--- a/src/pages/zh/agents/what-is-an-agent.md
+++ b/src/pages/zh/agents/what-is-an-agent.md
@@ -1,0 +1,51 @@
+---
+title: 什么是代理？
+metaTitle: Solana 上的代理是什么？ | Metaplex Agent Registry
+description: Solana 上的自主代理是具有内置钱包和链上身份记录的 MPL Core 资产。了解代理身份、钱包和执行委托的工作原理。
+keywords:
+  - Solana agents
+  - autonomous agents
+  - agent identity
+  - MPL Core
+  - execution delegation
+  - Asset Signer
+about:
+  - Autonomous Agents
+  - Solana
+  - Metaplex
+proficiencyLevel: Beginner
+created: '03-12-2026'
+updated: '03-12-2026'
+---
+
+Solana 上的自主代理是由 [Metaplex Agent Registry](/smart-contracts/mpl-agent) 管理的、具有内置钱包和链上身份记录的 [MPL Core](/smart-contracts/core) 资产。{% .lead %}
+
+## 概述
+
+代理是一个已注册链上身份的 MPL Core 资产，可以在自己的 PDA 派生钱包中持有资金。执行被委托给链下运营者，因此代理可以自主行动，无需所有者批准每笔交易。
+
+- **身份** — PDA 记录和 `AgentIdentity` 插件将可验证的身份绑定到 Core 资产
+- **钱包** — 资产的内置 PDA 钱包（Asset Signer）无需暴露私钥即可持有 SOL、代币和其他资产
+- **委托** — 链下执行者通过 Core 的 Execute 生命周期钩子代表代理签署交易
+- **所有者控制** — 所有者可以随时撤销或切换委托，而无需更改代理的身份或钱包
+
+## 代理资产的工作原理
+
+每个 [MPL Core](/smart-contracts/core) 资产都有一个内置钱包——一个从资产公钥派生的 PDA。不存在私钥，因此钱包无法被盗。只有资产本身才能通过 Core 的 [Execute](/smart-contracts/core/execute-asset-signing) 生命周期钩子为自己的钱包签名。
+
+这使得 Core 资产天然适合作为自主代理：
+
+- **资产就是代理的身份** — 通过 [AgentIdentity](/agents/register-agent) 插件在链上注册
+- **资产的 PDA 钱包持有代理的资金** — 仅由代理控制的 SOL、代币和其他资产
+- **执行者代表代理行动** — 由于 Solana 不支持后台任务或链上推理，委托的[执行者](/agents/run-an-agent)代表代理签署交易。所有者无需批准每个操作。
+
+所有者保留完全控制权。他们选择委托给哪个执行者，并可以随时撤销或切换委托——所有这些都无需更改代理的身份或钱包。
+
+## 下一步
+
+- **[技能](/agents/skill)** — 为 AI 编码代理提供 Metaplex 程序的完整知识
+- **[注册代理](/agents/register-agent)** — 将身份记录绑定到 MPL Core 资产
+- **[读取代理数据](/agents/run-agent)** — 验证注册并检查链上代理身份
+- **[运行代理](/agents/run-an-agent)** — 设置执行者配置文件并委托执行
+
+*由 Metaplex 维护 · 2026 年 3 月验证*


### PR DESCRIPTION
…agent registry

- Rename "Solana Agent Registry" to "Metaplex 014 agent registry" in NavList and register-agent page
- Add ja/ko/zh locale pages for all 9 agent section pages (index, what-is-an-agent, register-agent, run-agent, run-an-agent, skill/index, skill/how-it-works, skill/installation, skill/programs-and-operations)