### PR TITLE
Document Raydium fee collection on Genesis bonding curve

### DIFF
--- a/src/pages/en/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/en/smart-contracts/genesis/creator-fees.md
@@ -83,6 +83,8 @@ This section gives the minimum steps to configure and claim creator fees across 
 
 ### Quick Reference
 
+This table summarizes when to call each fee instruction, the accounts it requires, and its effect on the creator fee lifecycle.
+
 | Instruction | When to Use | Required Accounts | Output / Effect |
 |---|---|---|---|
 | `createAndRegisterLaunch` (set `creatorFeeWallet`) | Curve creation | Creator wallet, launch signer | Fee wallet configured on the bucket |

--- a/src/pages/en/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/en/smart-contracts/genesis/creator-fees.md
@@ -45,13 +45,13 @@ faqs:
   - q: Are creator fees transferred on every swap?
     a: No. Creator fees are accrued in the bucket (creatorFeeAccrued) on each swap but are not transferred immediately. Call claimBondingCurveCreatorFeeV2 to collect them during the active curve, and collectRaydiumCpmmFeesWithCreatorFeeV2 followed by claimRaydiumCreatorFeeV2 after graduation.
   - q: Can anyone call claimBondingCurveCreatorFeeV2 or claimRaydiumCreatorFeeV2?
-    a: Yes. Both instructions are permissionless — any wallet can trigger them, but the SOL is always sent to the configured creator fee wallet, not the caller. collectRaydiumCpmmFeesWithCreatorFeeV2 is also permissionless.
+    a: Yes. All three permissionless fee instructions span both active-curve and post-graduation phases — collectRaydiumCpmmFeesWithCreatorFeeV2 and claimBondingCurveCreatorFeeV2 (active curve), and claimRaydiumCreatorFeeV2 (post-graduation). Any wallet can trigger them, but the SOL is always sent to the configured creator fee wallet, not the caller.
   - q: What is the difference between collectRaydiumCpmmFeesWithCreatorFeeV2 and claimRaydiumCreatorFeeV2?
     a: collectRaydiumCpmmFeesWithCreatorFeeV2 harvests accumulated LP trading fees from the Raydium CPMM pool into the Genesis RaydiumCpmmBucketV2 bucket. claimRaydiumCreatorFeeV2 transfers the balance already in the bucket to the creator fee wallet. Both steps are required to fully collect post-graduation fees.
   - q: Does the first buy pay creator fees?
     a: No. When a first buy is configured, all fees — both the protocol swap fee and creator fee — are waived for that one initial purchase. All subsequent swaps pay the normal creator fee.
   - q: How do I check how much creator fee has accrued?
-    a: During the active curve, read the creatorFeeAccrued field from BondingCurveBucketV2 using fetchBondingCurveBucketV2. After graduation, read the same field from RaydiumCpmmBucketV2 using fetchRaydiumCpmmBucketV2.
+    a: During the active curve, read the creatorFeeAccrued field from BondingCurveBucketV2 using fetchBondingCurveBucketV2. After graduation, read creatorFeeAccrued from RaydiumCpmmBucketV2 using fetchRaydiumCpmmBucketV2. See the Checking Accrued Creator Fees and Checking Accrued Raydium Creator Fees sections.
   - q: Can I change the creator fee wallet after launch?
     a: No. The creator fee wallet is set at curve creation and cannot be changed after the curve is live.
 ---
@@ -79,6 +79,18 @@ For how creator fees interact with swap pricing and the protocol swap fee, see [
 
 ## Quick Start
 
+This section gives the minimum steps to configure and claim creator fees across both the active curve and post-graduation phases.
+
+### Quick Reference
+
+| Instruction | When to Use | Required Accounts | Output / Effect |
+|---|---|---|---|
+| `createAndRegisterLaunch` (set `creatorFeeWallet`) | Curve creation | Creator wallet, launch signer | Fee wallet configured on the bucket |
+| `fetchBondingCurveBucketV2` (read `creatorFeeAccrued`) | Any time during active curve | Bucket PDA | Current accrued fee balance (lamports) |
+| `claimBondingCurveCreatorFeeV2` | Active curve — collect accrued fees | Genesis account, bucket PDA, base mint, creator fee wallet | Accrued SOL transferred to creator wallet |
+| `collectRaydiumCpmmFeesWithCreatorFeeV2` | Post-graduation — harvest LP fees | Genesis account, Raydium pool PDAs, Raydium bucket PDA | LP fees moved from Raydium pool into Genesis bucket |
+| `claimRaydiumCreatorFeeV2` | Post-graduation — claim bucket balance | Genesis account, Raydium bucket PDA, base/quote mints, creator fee wallet | Bucket balance transferred to creator wallet |
+
 **Jump to:** [Configure at Launch](#configuring-a-creator-fee-at-launch) · [Redirect to Wallet](#redirecting-creator-fees-to-a-specific-wallet) · [Agent PDA](#agent-launches-automatic-pda-routing) · [Combine with First Buy](#combining-creator-fees-with-a-first-buy) · [Check Accrued (Curve)](#checking-accrued-creator-fees) · [Claim During Curve](#claiming-creator-fees-during-the-active-curve) · [Check Raydium Fees](#checking-accrued-raydium-creator-fees) · [Collect from Raydium](#step-1--collect-fees-from-the-raydium-cpmm-pool) · [Claim After Graduation](#step-2--claim-fees-to-the-creator-wallet)
 
 1. Set `creatorFeeWallet` in the `launch` object when calling `createAndRegisterLaunch`
@@ -88,6 +100,8 @@ For how creator fees interact with swap pricing and the protocol swap fee, see [
 5. Call `claimRaydiumCreatorFeeV2` to transfer the bucket balance to the creator wallet
 
 ## Prerequisites
+
+You must have the Genesis SDK, a configured Umi instance, and a funded Solana wallet.
 
 - `@metaplex-foundation/genesis` SDK installed
 - A Umi instance configured with your keypair identity — see [Launching a Bonding Curve via the Metaplex API](/smart-contracts/genesis/bonding-curve-launch#umi-setup)
@@ -377,6 +391,8 @@ console.log('Raydium creator fees collected and claimed to:', creatorFeeWallet.t
 
 ## Notes
 
+These caveats cover fee timing, permissionless claiming, the two-step post-graduation flow, and first-buy fee waivers.
+
 - Creator fees are accrued in the bucket (`creatorFeeAccrued`) on each swap, not transferred immediately — explicitly call the claim instructions to receive them; `creatorFeeClaimed` tracks the cumulative total claimed to date
 - Both `claimBondingCurveCreatorFeeV2` and `claimRaydiumCreatorFeeV2` are permissionless: any wallet can trigger them, but the SOL always goes to the configured creator fee wallet, not the caller; `collectRaydiumCpmmFeesWithCreatorFeeV2` is also permissionless
 - Post-graduation fees require two steps in order: `collectRaydiumCpmmFeesWithCreatorFeeV2` (harvest from Raydium pool → Genesis bucket), then `claimRaydiumCreatorFeeV2` (bucket → creator wallet); both can be combined in a single transaction
@@ -399,7 +415,7 @@ No. Creator fees are accrued in the bucket (`creatorFeeAccrued`) on each swap bu
 
 ### Can anyone call `claimBondingCurveCreatorFeeV2` or `claimRaydiumCreatorFeeV2`?
 
-Yes. All three post-graduation instructions — `collectRaydiumCpmmFeesWithCreatorFeeV2`, `claimBondingCurveCreatorFeeV2`, and `claimRaydiumCreatorFeeV2` — are permissionless. Any wallet can trigger them, but the SOL is always sent to the configured creator fee wallet, not the caller.
+Yes. All three permissionless fee instructions span both the active-curve and post-graduation phases — `collectRaydiumCpmmFeesWithCreatorFeeV2` and `claimBondingCurveCreatorFeeV2` (active curve), and `claimRaydiumCreatorFeeV2` (post-graduation). Any wallet can trigger them, but the SOL is always sent to the configured creator fee wallet, not the caller.
 
 ### What is the difference between `collectRaydiumCpmmFeesWithCreatorFeeV2` and `claimRaydiumCreatorFeeV2`?
 
@@ -415,7 +431,7 @@ No. When a first buy is configured, all fees — protocol swap fee and creator f
 
 ### How do I check how much creator fee has accrued?
 
-Read the `creatorFeeAccrued` field from the bucket account using `fetchBondingCurveBucketV2`. See [Checking Accrued Creator Fees](#checking-accrued-creator-fees).
+During the active curve, read the `creatorFeeAccrued` field from `BondingCurveBucketV2` using `fetchBondingCurveBucketV2`. After graduation, read `creatorFeeAccrued` from `RaydiumCpmmBucketV2` using `fetchRaydiumCpmmBucketV2`. See [Checking Accrued Creator Fees](#checking-accrued-creator-fees) and [Checking Accrued Raydium Creator Fees](#checking-accrued-raydium-creator-fees).
 
 ### Can I change the creator fee wallet after launch?
 

--- a/src/pages/ja/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/ja/smart-contracts/genesis/creator-fees.md
@@ -39,11 +39,11 @@ faqs:
   - q: クリエイター手数料はスワップごとに転送されますか？
     a: いいえ。クリエイター手数料は各スワップでバケット（creatorFeeAccrued）に蓄積されますが、すぐには転送されません。アクティブなカーブ中はclaimBondingCurveCreatorFeeV2で、グラデュエーション後はclaimRaydiumCreatorFeeV2で請求します。
   - q: 誰でもclaimBondingCurveCreatorFeeV2を呼び出せますか？
-    a: はい。claimBondingCurveCreatorFeeV2とclaimRaydiumCreatorFeeV2はどちらもパーミッションレスです — どのウォレットでも請求をトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
+    a: はい。3つのパーミッションレスな手数料インストラクションはアクティブカーブとグラデュエーション後の両方のフェーズにまたがります — collectRaydiumCpmmFeesWithCreatorFeeV2とclaimBondingCurveCreatorFeeV2（アクティブカーブ）、およびclaimRaydiumCreatorFeeV2（グラデュエーション後）。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
   - q: ファーストバイはクリエイター手数料を支払いますか？
     a: いいえ。ファーストバイが設定されている場合、プロトコルスワップ手数料とクリエイター手数料の両方が、その1回の初回購入に対して免除されます。その後のすべてのスワップは通常のクリエイター手数料を支払います。
   - q: 蓄積したクリエイター手数料を確認するにはどうすればよいですか？
-    a: Genesis SDKのfetchBondingCurveBucketV2を使用して、バケットアカウントからcreatorFeeAccruedフィールドを読み取ります。
+    a: アクティブカーブ中はfetchBondingCurveBucketV2を使用してBondingCurveBucketV2からcreatorFeeAccruedフィールドを読み取ります。グラデュエーション後はfetchRaydiumCpmmBucketV2を使用してRaydiumCpmmBucketV2からcreatorFeeAccruedを読み取ります。蓄積したクリエイター手数料の確認セクションを参照してください。
   - q: ローンチ後にクリエイター手数料ウォレットを変更できますか？
     a: いいえ。クリエイター手数料ウォレットはカーブ作成時に設定され、カーブがライブになった後は変更できません。
 ---
@@ -71,6 +71,18 @@ faqs:
 
 ## クイックスタート
 
+このセクションでは、アクティブカーブとグラデュエーション後の両フェーズでクリエイター手数料を設定および請求するための最小限の手順を説明します。
+
+### クイックリファレンス
+
+| インストラクション | 使用タイミング | 必要なアカウント | 出力 / 効果 |
+|---|---|---|---|
+| `createAndRegisterLaunch`（`creatorFeeWallet` 設定） | カーブ作成時 | クリエイターウォレット、ローンチ署名者 | バケットに手数料ウォレットが設定される |
+| `fetchBondingCurveBucketV2`（`creatorFeeAccrued` 読み取り） | アクティブカーブ中いつでも | バケットPDA | 現在の蓄積手数料残高（lamports） |
+| `claimBondingCurveCreatorFeeV2` | アクティブカーブ — 蓄積手数料の回収 | Genesisアカウント、バケットPDA、ベースミント、クリエイター手数料ウォレット | 蓄積SOLがクリエイターウォレットに転送 |
+| `collectRaydiumCpmmFeesWithCreatorFeeV2` | グラデュエーション後 — LP手数料のハーベスト | Genesisアカウント、RaydiumプールPDA、Raydiumバケット PDA | LP手数料がRaydiumプールからGenesisバケットに移動 |
+| `claimRaydiumCreatorFeeV2` | グラデュエーション後 — バケット残高の請求 | Genesisアカウント、RaydiumバケットPDA、ベース/クォートミント、クリエイター手数料ウォレット | バケット残高がクリエイターウォレットに転送 |
+
 **ジャンプ:** [ローンチ時の設定](#ローンチ時のクリエイター手数料の設定) · [ウォレットへのリダイレクト](#クリエイター手数料を特定のウォレットにリダイレクトする) · [エージェントPDA](#エージェントローンチ自動pda ルーティング) · [ファーストバイとの組み合わせ](#クリエイター手数料とファーストバイの組み合わせ) · [蓄積確認](#蓄積したクリエイター手数料の確認) · [カーブ中の請求](#アクティブなカーブ中のクリエイター手数料の請求) · [グラデュエーション後の請求](#グラデュエーション後のクリエイター手数料の請求)
 
 1. `createAndRegisterLaunch` を呼び出すときに `launch` オブジェクトに `creatorFeeWallet` を設定する
@@ -79,6 +91,8 @@ faqs:
 4. グラデュエーション後、`claimRaydiumCreatorFeeV2` を呼び出してRaydium LP手数料を回収する
 
 ## 前提条件
+
+Genesis SDK、設定済みのUmiインスタンス、および入金済みのSolanaウォレットが必要です。
 
 - `@metaplex-foundation/genesis` SDKインストール済み
 - キーペアIDで設定されたUmiインスタンス — [Metaplex APIを通じたボンディングカーブのローンチ](/smart-contracts/genesis/bonding-curve-launch#umiセットアップ)を参照
@@ -203,6 +217,8 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ## Notes
 
+以下の注意事項は、手数料のタイミング、パーミッションレスな請求、2ステップのグラデュエーション後フロー、およびファーストバイの手数料免除について説明します。
+
 - クリエイター手数料は各スワップでバケット（`creatorFeeAccrued`）に蓄積されますが、すぐには転送されません — 受け取るには明示的に請求インストラクションを呼び出す必要があります。`creatorFeeClaimed` は累計の請求済み合計を追跡します
 - 両方の請求インストラクションはパーミッションレスです。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません
 - `creatorFeeWallet` は設定されていない場合デフォルトでローンチウォレットになります。カーブ作成後は変更できません
@@ -223,7 +239,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 誰でも `claimBondingCurveCreatorFeeV2` を呼び出せますか？
 
-はい。`claimBondingCurveCreatorFeeV2` と `claimRaydiumCreatorFeeV2` はどちらもパーミッションレスです — どのウォレットでも請求をトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
+はい。3つのパーミッションレスな手数料インストラクションはアクティブカーブとグラデュエーション後の両方のフェーズにまたがります — `collectRaydiumCpmmFeesWithCreatorFeeV2` と `claimBondingCurveCreatorFeeV2`（アクティブカーブ）、および `claimRaydiumCreatorFeeV2`（グラデュエーション後）。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
 
 ### ファーストバイはクリエイター手数料を支払いますか？
 
@@ -231,7 +247,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 蓄積したクリエイター手数料を確認するにはどうすればよいですか？
 
-`fetchBondingCurveBucketV2` を使用してバケットアカウントから `creatorFeeAccrued` フィールドを読み取ります。[蓄積したクリエイター手数料の確認](#蓄積したクリエイター手数料の確認)を参照してください。
+アクティブカーブ中は `fetchBondingCurveBucketV2` を使用して `BondingCurveBucketV2` から `creatorFeeAccrued` フィールドを読み取ります。グラデュエーション後は `fetchRaydiumCpmmBucketV2` を使用して `RaydiumCpmmBucketV2` から `creatorFeeAccrued` を読み取ります。[蓄積したクリエイター手数料の確認](#蓄積したクリエイター手数料の確認)を参照してください。
 
 ### ローンチ後にクリエイター手数料ウォレットを変更できますか？
 

--- a/src/pages/ja/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/ja/smart-contracts/genesis/creator-fees.md
@@ -1,15 +1,20 @@
 ---
 title: Genesis ボンディングカーブのクリエイター手数料
 metaTitle: Genesis ボンディングカーブのクリエイター手数料 — 設定と請求 | Metaplex
-description: Genesis ボンディングカーブのローンチでクリエイター手数料を設定し、アクティブなカーブ中およびRaydium CPMMプールへのグラデュエーション後に蓄積した手数料を請求する方法。
+description: Genesis ボンディングカーブのローンチでクリエイター手数料を設定し、アクティブなカーブ中に蓄積した手数料を請求し、Raydium CPMMプールからグラデュエーション後の手数料を収集・請求する方法。
 keywords:
   - creator fee
   - bonding curve
   - genesis
   - claimBondingCurveCreatorFeeV2
   - claimRaydiumCreatorFeeV2
+  - collectRaydiumCpmmFeesWithCreatorFeeV2
+  - deriveRaydiumPDAsV2
+  - findRaydiumCpmmBucketV2Pda
+  - fetchRaydiumCpmmBucketV2
   - creatorFeeWallet
   - creatorFeeAccrued
+  - RaydiumCpmmBucketV2
   - Raydium CPMM
   - token launch
   - Solana
@@ -23,12 +28,13 @@ programmingLanguage:
   - TypeScript
 proficiencyLevel: Intermediate
 created: '04-09-2026'
-updated: '04-09-2026'
+updated: '04-13-2026'
 howToSteps:
   - Set creatorFeeWallet in the launch object when calling createAndRegisterLaunch
   - After launch, monitor creatorFeeAccrued in the bucket account using fetchBondingCurveBucketV2
   - Call claimBondingCurveCreatorFeeV2 to collect accrued fees during the active curve
-  - After graduation, call claimRaydiumCreatorFeeV2 to collect fees from the Raydium CPMM pool
+  - After graduation, call collectRaydiumCpmmFeesWithCreatorFeeV2 to harvest LP fees from the Raydium pool into the Genesis bucket
+  - Call claimRaydiumCreatorFeeV2 to transfer the accumulated bucket balance to the creator wallet
 howToTools:
   - Node.js
   - Umi framework
@@ -37,13 +43,15 @@ faqs:
   - q: creatorFeeWalletが設定されていない場合、デフォルトのクリエイター手数料ウォレットは何ですか？
     a: デフォルトはローンチウォレット — createLaunch呼び出しに署名したウォレットです。launchオブジェクトにcreatorFeeWalletを明示的に設定して、手数料を他のアドレスにリダイレクトします。
   - q: クリエイター手数料はスワップごとに転送されますか？
-    a: いいえ。クリエイター手数料は各スワップでバケット（creatorFeeAccrued）に蓄積されますが、すぐには転送されません。アクティブなカーブ中はclaimBondingCurveCreatorFeeV2で、グラデュエーション後はclaimRaydiumCreatorFeeV2で請求します。
-  - q: 誰でもclaimBondingCurveCreatorFeeV2を呼び出せますか？
+    a: いいえ。クリエイター手数料は各スワップでバケット（creatorFeeAccrued）に蓄積されますが、すぐには転送されません。アクティブなカーブ中はclaimBondingCurveCreatorFeeV2で請求します。グラデュエーション後はcollectRaydiumCpmmFeesWithCreatorFeeV2でRaydiumプールからLP手数料を収集し、その後claimRaydiumCreatorFeeV2でクリエイターウォレットに転送します。
+  - q: 誰でもclaimBondingCurveCreatorFeeV2やclaimRaydiumCreatorFeeV2を呼び出せますか？
     a: はい。3つのパーミッションレスな手数料インストラクションはアクティブカーブとグラデュエーション後の両方のフェーズにまたがります — collectRaydiumCpmmFeesWithCreatorFeeV2とclaimBondingCurveCreatorFeeV2（アクティブカーブ）、およびclaimRaydiumCreatorFeeV2（グラデュエーション後）。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
+  - q: collectRaydiumCpmmFeesWithCreatorFeeV2とclaimRaydiumCreatorFeeV2の違いは何ですか？
+    a: collectRaydiumCpmmFeesWithCreatorFeeV2はRaydium CPMMプールから蓄積されたLP取引手数料をGenesisのRaydiumCpmmBucketV2バケットに収集します。claimRaydiumCreatorFeeV2はバケットにある残高をクリエイター手数料ウォレットに転送します。グラデュエーション後の手数料を完全に回収するには両方のステップが必要です。
   - q: ファーストバイはクリエイター手数料を支払いますか？
     a: いいえ。ファーストバイが設定されている場合、プロトコルスワップ手数料とクリエイター手数料の両方が、その1回の初回購入に対して免除されます。その後のすべてのスワップは通常のクリエイター手数料を支払います。
   - q: 蓄積したクリエイター手数料を確認するにはどうすればよいですか？
-    a: アクティブカーブ中はfetchBondingCurveBucketV2を使用してBondingCurveBucketV2からcreatorFeeAccruedフィールドを読み取ります。グラデュエーション後はfetchRaydiumCpmmBucketV2を使用してRaydiumCpmmBucketV2からcreatorFeeAccruedを読み取ります。蓄積したクリエイター手数料の確認セクションを参照してください。
+    a: アクティブカーブ中はfetchBondingCurveBucketV2を使用してBondingCurveBucketV2からcreatorFeeAccruedフィールドを読み取ります。グラデュエーション後はfetchRaydiumCpmmBucketV2を使用してRaydiumCpmmBucketV2からcreatorFeeAccruedを読み取ります。蓄積したクリエイター手数料の確認および蓄積したRaydiumクリエイター手数料の確認セクションを参照してください。
   - q: ローンチ後にクリエイター手数料ウォレットを変更できますか？
     a: いいえ。クリエイター手数料ウォレットはカーブ作成時に設定され、カーブがライブになった後は変更できません。
 ---
@@ -65,7 +73,7 @@ faqs:
 - **設定** — カーブ作成時に `launch` オブジェクトに `creatorFeeWallet` を設定する。省略するとデフォルトでローンチウォレットになる
 - **蓄積** — `creatorFeeAccrued` はスワップごとに増加する。手数料はスワップごとに転送されない
 - **アクティブカーブ中の請求** — `claimBondingCurveCreatorFeeV2` でカーブがライブ中に蓄積した手数料を回収する
-- **グラデュエーション後の請求** — `claimRaydiumCreatorFeeV2` でカーブがグラデュエーションした後にRaydium CPMMプールから手数料を回収する
+- **グラデュエーション後の請求** — 2ステップ: `collectRaydiumCpmmFeesWithCreatorFeeV2` でRaydiumプールからLP手数料をGenesisバケットに収集し、その後 `claimRaydiumCreatorFeeV2` でバケット残高をクリエイターウォレットに転送する
 
 スワップ価格設定とプロトコルスワップ手数料とのクリエイター手数料の相互作用については、[動作理論 — 手数料構造](/smart-contracts/genesis/bonding-curve-theory#fee-structure)を参照してください。
 
@@ -80,22 +88,23 @@ faqs:
 | `createAndRegisterLaunch`（`creatorFeeWallet` 設定） | カーブ作成時 | クリエイターウォレット、ローンチ署名者 | バケットに手数料ウォレットが設定される |
 | `fetchBondingCurveBucketV2`（`creatorFeeAccrued` 読み取り） | アクティブカーブ中いつでも | バケットPDA | 現在の蓄積手数料残高（lamports） |
 | `claimBondingCurveCreatorFeeV2` | アクティブカーブ — 蓄積手数料の回収 | Genesisアカウント、バケットPDA、ベースミント、クリエイター手数料ウォレット | 蓄積SOLがクリエイターウォレットに転送 |
-| `collectRaydiumCpmmFeesWithCreatorFeeV2` | グラデュエーション後 — LP手数料のハーベスト | Genesisアカウント、RaydiumプールPDA、Raydiumバケット PDA | LP手数料がRaydiumプールからGenesisバケットに移動 |
+| `collectRaydiumCpmmFeesWithCreatorFeeV2` | グラデュエーション後 — LP手数料のハーベスト | Genesisアカウント、RaydiumプールPDA、RaydiumバケットPDA | LP手数料がRaydiumプールからGenesisバケットに移動 |
 | `claimRaydiumCreatorFeeV2` | グラデュエーション後 — バケット残高の請求 | Genesisアカウント、RaydiumバケットPDA、ベース/クォートミント、クリエイター手数料ウォレット | バケット残高がクリエイターウォレットに転送 |
 
-**ジャンプ:** [ローンチ時の設定](#ローンチ時のクリエイター手数料の設定) · [ウォレットへのリダイレクト](#クリエイター手数料を特定のウォレットにリダイレクトする) · [エージェントPDA](#エージェントローンチ自動pda ルーティング) · [ファーストバイとの組み合わせ](#クリエイター手数料とファーストバイの組み合わせ) · [蓄積確認](#蓄積したクリエイター手数料の確認) · [カーブ中の請求](#アクティブなカーブ中のクリエイター手数料の請求) · [グラデュエーション後の請求](#グラデュエーション後のクリエイター手数料の請求)
+**ジャンプ:** [ローンチ時の設定](#ローンチ時のクリエイター手数料の設定) · [ウォレットへのリダイレクト](#クリエイター手数料を特定のウォレットにリダイレクトする) · [エージェントPDA](#エージェントローンチ自動pdaルーティング) · [ファーストバイとの組み合わせ](#クリエイター手数料とファーストバイの組み合わせ) · [蓄積確認（カーブ）](#蓄積したクリエイター手数料の確認) · [カーブ中の請求](#アクティブなカーブ中のクリエイター手数料の請求) · [Raydium手数料の確認](#蓄積したraydiumクリエイター手数料の確認) · [Raydiumからの収集](#ステップ1--raydium-cpmmプールからの手数料収集) · [グラデュエーション後の請求](#ステップ2--クリエイターウォレットへの手数料請求)
 
 1. `createAndRegisterLaunch` を呼び出すときに `launch` オブジェクトに `creatorFeeWallet` を設定する
 2. ローンチ後、`bucket.creatorFeeAccrued` を監視して蓄積手数料を追跡する
 3. `claimBondingCurveCreatorFeeV2` を呼び出してカーブがアクティブな間に手数料を回収する
-4. グラデュエーション後、`claimRaydiumCreatorFeeV2` を呼び出してRaydium LP手数料を回収する
+4. グラデュエーション後、`collectRaydiumCpmmFeesWithCreatorFeeV2` を呼び出してRaydiumプールからLP手数料を収集する
+5. `claimRaydiumCreatorFeeV2` を呼び出してバケット残高をクリエイターウォレットに転送する
 
 ## 前提条件
 
 Genesis SDK、設定済みのUmiインスタンス、および入金済みのSolanaウォレットが必要です。
 
 - `@metaplex-foundation/genesis` SDKインストール済み
-- キーペアIDで設定されたUmiインスタンス — [Metaplex APIを通じたボンディングカーブのローンチ](/smart-contracts/genesis/bonding-curve-launch#umiセットアップ)を参照
+- キーペアIDで設定されたUmiインスタンス — [Metaplex APIを通じたボンディングカーブのローンチ](/smart-contracts/genesis/bonding-curve-launch#umi-setup)を参照
 - トランザクション手数料のための入金済みSolanaウォレット
 
 ## ローンチ時のクリエイター手数料の設定
@@ -129,7 +138,7 @@ const result = await createAndRegisterLaunch(umi, {}, {
 
 ### エージェントローンチ — 自動PDAルーティング
 
-MetaplexエージェントのためにローンチするSolana場合、クリエイター手数料は `creatorFeeWallet` を手動設定せずにエージェントのPDAに自動的にルーティングされます。Coreエグゼキュートラッピングと `setToken` 関連付けを含む完全なエージェントローンチフローについては、[エージェントトークンの作成](/agents/create-agent-token)を参照してください。
+Metaplexエージェントのためにローンチする場合、クリエイター手数料は `creatorFeeWallet` を手動設定せずにエージェントのPDAに自動的にルーティングされます。Coreエグゼキュートラッピングと `setToken` 関連付けを含む完全なエージェントローンチフローについては、[エージェントトークンの作成](/agents/create-agent-token)を参照してください。
 
 ### クリエイター手数料とファーストバイの組み合わせ
 
@@ -200,27 +209,194 @@ console.log('Creator fees claimed:', result.signature);
 
 ## グラデュエーション後のクリエイター手数料の請求
 
-ボンディングカーブが[グラデュエーション](/smart-contracts/genesis/bonding-curve-theory#phase-3-graduated)した後、流動性はRaydium CPMMプールに移行し、クリエイター手数料はLPの取引活動から引き続き蓄積されます。`RaydiumCpmmBucketV2` アカウントは、`BondingCurveBucketV2` と同様の `creatorFeeAccrued` と `creatorFeeClaimed` フィールドを公開します。グラデュエーション後の手数料は `claimRaydiumCreatorFeeV2` で回収します。
+ボンディングカーブが[グラデュエーション](/smart-contracts/genesis/bonding-curve-theory#phase-3-graduated)した後、流動性はRaydium CPMMプールに移行し、クリエイター手数料はLPの取引活動から引き続き蓄積されます。グラデュエーション後の手数料回収は**2ステップのプロセス**です：まずRaydiumプールから蓄積されたLP取引手数料をGenesisの `RaydiumCpmmBucketV2` バケットに収集し、次にバケット残高をクリエイターウォレットに請求します。
 
-```typescript {% title="claim-raydium-creator-fees.ts" showLineNumbers=true %}
-import { claimRaydiumCreatorFeeV2 } from '@metaplex-foundation/genesis';
+### 蓄積したRaydiumクリエイター手数料の確認
 
-const result = await claimRaydiumCreatorFeeV2(umi, {
+`RaydiumCpmmBucketV2` アカウントは `BondingCurveBucketV2` と同様の `creatorFeeAccrued` と `creatorFeeClaimed` フィールドを公開します。`findRaydiumCpmmBucketV2Pda` と `fetchRaydiumCpmmBucketV2` を使用してデリブおよびフェッチします。
+
+```typescript {% title="check-raydium-fees.ts" showLineNumbers=true %}
+import {
+  findRaydiumCpmmBucketV2Pda,
+  fetchRaydiumCpmmBucketV2,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey } from '@metaplex-foundation/umi';
+
+const genesisAccount = publicKey('YOUR_GENESIS_ACCOUNT_PUBKEY');
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
   genesisAccount,
-  // ... Raydiumプールアカウント
-}).sendAndConfirm(umi);
+  bucketIndex: 0,
+});
+
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+const claimable = raydiumBucket.creatorFeeAccrued - raydiumBucket.creatorFeeClaimed;
+console.log('Claimable Raydium creator fees (lamports):', claimable);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+const creatorFeeWallet = isSome(creatorFeeExt) ? creatorFeeExt.value.wallet : null;
+console.log('Creator fee wallet:', creatorFeeWallet?.toString() ?? 'none configured');
 ```
 
 {% callout type="note" %}
-ボンディングカーブの対応するインストラクションと同様に、`claimRaydiumCreatorFeeV2` もパーミッションレスです — どのウォレットでも請求をトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られます。
+`raydiumBucket.creatorFeeAccrued` はRaydiumプールからバケットに既に収集された手数料のみを反映します。Raydiumプール自体に未収集のLP手数料がある場合があります — 最終的な請求可能残高を読み取る前に `collectRaydiumCpmmFeesWithCreatorFeeV2` を実行してバケットに移動してください。
 {% /callout %}
+
+### ステップ1 — Raydium CPMMプールからの手数料収集
+
+`collectRaydiumCpmmFeesWithCreatorFeeV2` はRaydium CPMMプールから蓄積されたLP取引手数料を収集し、`RaydiumCpmmBucketV2` バケット署名者のトークンアカウントにクレジットし、`creatorFeeAccrued` を更新します。請求前にこのステップを実行する必要があります — Raydiumから手数料が収集されるまで、請求するものはありません。
+
+`deriveRaydiumPDAsV2` を使用して、ベースミントとバケットアドレスから必要なすべてのRaydiumプールアカウントを計算します。`creatorFee: true` を渡してクリエイター手数料AMMコンフィグを選択します。
+
+```typescript {% title="collect-raydium-fees.ts" showLineNumbers=true %}
+import {
+  collectRaydiumCpmmFeesWithCreatorFeeV2,
+  deriveRaydiumPDAsV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { publicKey } from '@metaplex-foundation/umi';
+
+const baseMint = publicKey('TOKEN_MINT_PUBKEY');
+const quoteMint = publicKey('So11111111111111111111111111111111111111112'); // wSOL
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+const pdas = deriveRaydiumPDAsV2(umi, baseMint, raydiumBucketPda, {
+  quoteMint,
+  env: 'mainnet', // or 'devnet'
+  creatorFee: true,
+});
+
+await collectRaydiumCpmmFeesWithCreatorFeeV2(umi, {
+  baseMint,
+  quoteMint,
+  genesisAccount,
+  poolState: pdas.poolState,
+  raydiumCpmmBucket: raydiumBucketPda,
+  ammConfig: pdas.ammConfig,
+  poolAuthority: pdas.poolAuthority,
+  baseVault: pdas.baseVault,
+  quoteVault: pdas.quoteVault,
+  raydiumProgram: pdas.raydiumProgram,
+}).sendAndConfirm(umi);
+
+console.log('Raydium LP fees collected into Genesis bucket');
+```
+
+{% callout type="note" %}
+`collectRaydiumCpmmFeesWithCreatorFeeV2` はパーミッションレスです — どのウォレットでも呼び出せます。収集された手数料はGenesisバケット署名者のトークンアカウントに流れ、次回のバケットフェッチで `creatorFeeAccrued` に反映されます。
+{% /callout %}
+
+### ステップ2 — クリエイターウォレットへの手数料請求
+
+`claimRaydiumCreatorFeeV2` は `RaydiumCpmmBucketV2` バケットに蓄積された残高を設定されたクリエイター手数料ウォレットに転送します。収集後に実行するか、前回の収集からバケットに未請求残高がある場合はいつでも実行します。
+
+```typescript {% title="claim-raydium-creator-fees.ts" showLineNumbers=true %}
+import {
+  claimRaydiumCreatorFeeV2,
+  fetchRaydiumCpmmBucketV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey } from '@metaplex-foundation/umi';
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+// 収集後に再フェッチして更新されたcreatorFeeAccruedを取得する。
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured on this Raydium bucket');
+const creatorFeeWallet = creatorFeeExt.value.wallet;
+
+await claimRaydiumCreatorFeeV2(umi, {
+  genesisAccount: raydiumBucket.bucket.genesis,
+  bucket: raydiumBucketPda,
+  baseMint: raydiumBucket.bucket.baseMint,
+  quoteMint: raydiumBucket.bucket.quoteMint,
+  creatorFeeWallet,
+}).sendAndConfirm(umi);
+
+console.log('Raydium creator fees claimed to:', creatorFeeWallet.toString());
+```
+
+{% callout type="note" %}
+`claimRaydiumCreatorFeeV2` はパーミッションレスです — どのウォレットでも請求をトリガーできますが、SOL（wSOLとして）は常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
+{% /callout %}
+
+### 収集と請求の統合フロー
+
+2つのビルダーをチェーンして1つのトランザクションで収集と請求を行います。プールに未収集手数料がなくバケット残高もゼロの場合、無操作トランザクションを避けるため両方のインストラクションをスキップします。
+
+```typescript {% title="collect-and-claim-raydium.ts" showLineNumbers=true %}
+import {
+  collectRaydiumCpmmFeesWithCreatorFeeV2,
+  claimRaydiumCreatorFeeV2,
+  deriveRaydiumPDAsV2,
+  fetchRaydiumCpmmBucketV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey, transactionBuilder } from '@metaplex-foundation/umi';
+
+const baseMint = publicKey('TOKEN_MINT_PUBKEY');
+const quoteMint = publicKey('So11111111111111111111111111111111111111112');
+const genesisAccount = publicKey('YOUR_GENESIS_ACCOUNT_PUBKEY');
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured');
+const creatorFeeWallet = creatorFeeExt.value.wallet;
+
+const pdas = deriveRaydiumPDAsV2(umi, baseMint, raydiumBucketPda, {
+  quoteMint,
+  env: 'mainnet', // or 'devnet'
+  creatorFee: true,
+});
+
+await transactionBuilder()
+  .add(collectRaydiumCpmmFeesWithCreatorFeeV2(umi, {
+    baseMint,
+    quoteMint,
+    genesisAccount,
+    poolState: pdas.poolState,
+    raydiumCpmmBucket: raydiumBucketPda,
+    ammConfig: pdas.ammConfig,
+    poolAuthority: pdas.poolAuthority,
+    baseVault: pdas.baseVault,
+    quoteVault: pdas.quoteVault,
+    raydiumProgram: pdas.raydiumProgram,
+  }))
+  .add(claimRaydiumCreatorFeeV2(umi, {
+    genesisAccount,
+    bucket: raydiumBucketPda,
+    baseMint,
+    quoteMint,
+    creatorFeeWallet,
+  }))
+  .sendAndConfirm(umi);
+
+console.log('Raydium creator fees collected and claimed to:', creatorFeeWallet.toString());
+```
 
 ## Notes
 
 以下の注意事項は、手数料のタイミング、パーミッションレスな請求、2ステップのグラデュエーション後フロー、およびファーストバイの手数料免除について説明します。
 
 - クリエイター手数料は各スワップでバケット（`creatorFeeAccrued`）に蓄積されますが、すぐには転送されません — 受け取るには明示的に請求インストラクションを呼び出す必要があります。`creatorFeeClaimed` は累計の請求済み合計を追跡します
-- 両方の請求インストラクションはパーミッションレスです。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません
+- `claimBondingCurveCreatorFeeV2` と `claimRaydiumCreatorFeeV2` はともにパーミッションレスです。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。`collectRaydiumCpmmFeesWithCreatorFeeV2` もパーミッションレスです
+- グラデュエーション後の手数料には順序通り2つのステップが必要です：`collectRaydiumCpmmFeesWithCreatorFeeV2`（Raydiumプール → Genesisバケットへの収集）、次に `claimRaydiumCreatorFeeV2`（バケット → クリエイターウォレット）。両方を1つのトランザクションにまとめることができます
+- `creatorFeeAccrued` と `creatorFeeClaimed` は `BondingCurveBucketV2`（アクティブカーブ）と `RaydiumCpmmBucketV2`（グラデュエーション後）の両方に存在します。それぞれ `fetchBondingCurveBucketV2` と `fetchRaydiumCpmmBucketV2` を使用します
 - `creatorFeeWallet` は設定されていない場合デフォルトでローンチウォレットになります。カーブ作成後は変更できません
 - ファーストバイの仕組みは、指定された初回購入のみすべての手数料（プロトコルとクリエイター）を免除します。その後のすべてのスワップは通常のクリエイター手数料を支払います
 - クリエイター手数料は方向（購入または売却）に関わらずすべてのスワップのSOL側に適用されます。プロトコルスワップ手数料とは複合しません
@@ -235,11 +411,19 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### クリエイター手数料はスワップごとに転送されますか？
 
-いいえ。クリエイター手数料は各スワップでバケット（`creatorFeeAccrued`）に蓄積されますが、すぐには転送されません。アクティブなカーブ中は `claimBondingCurveCreatorFeeV2` で、グラデュエーション後は `claimRaydiumCreatorFeeV2` で請求します。
+いいえ。クリエイター手数料は各スワップでバケット（`creatorFeeAccrued`）に蓄積されますが、すぐには転送されません。アクティブなカーブ中は `claimBondingCurveCreatorFeeV2` で請求します。グラデュエーション後は `collectRaydiumCpmmFeesWithCreatorFeeV2` でRaydiumプールからLP手数料を収集し、その後 `claimRaydiumCreatorFeeV2` でクリエイターウォレットに転送します。
 
-### 誰でも `claimBondingCurveCreatorFeeV2` を呼び出せますか？
+### 誰でも `claimBondingCurveCreatorFeeV2` や `claimRaydiumCreatorFeeV2` を呼び出せますか？
 
 はい。3つのパーミッションレスな手数料インストラクションはアクティブカーブとグラデュエーション後の両方のフェーズにまたがります — `collectRaydiumCpmmFeesWithCreatorFeeV2` と `claimBondingCurveCreatorFeeV2`（アクティブカーブ）、および `claimRaydiumCreatorFeeV2`（グラデュエーション後）。どのウォレットでもトリガーできますが、SOLは常に設定されたクリエイター手数料ウォレットに送られ、呼び出し元には送られません。
+
+### `collectRaydiumCpmmFeesWithCreatorFeeV2` と `claimRaydiumCreatorFeeV2` の違いは何ですか？
+
+`collectRaydiumCpmmFeesWithCreatorFeeV2` はRaydium CPMMプールから蓄積されたLP取引手数料をGenesisの `RaydiumCpmmBucketV2` バケットに収集します — これによりバケットの `creatorFeeAccrued` が更新されます。`claimRaydiumCreatorFeeV2` はそのバケット残高をクリエイター手数料ウォレットに転送します。収集を請求の前に実行する必要があります — 収集なしでは、請求するバケット残高がありません。
+
+### Raydiumバケットの `creatorFeeAccrued` がプールがアクティブなのにゼロなのはなぜですか？
+
+`RaydiumCpmmBucketV2` の `creatorFeeAccrued` は、`collectRaydiumCpmmFeesWithCreatorFeeV2` を通じてRaydiumからGenesisバケットに収集された手数料のみを反映します。LP取引手数料はまずRaydiumプールステート内に蓄積されます — 収集インストラクションを実行するまでGenesisバケットには表示されません。
 
 ### ファーストバイはクリエイター手数料を支払いますか？
 
@@ -247,7 +431,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 蓄積したクリエイター手数料を確認するにはどうすればよいですか？
 
-アクティブカーブ中は `fetchBondingCurveBucketV2` を使用して `BondingCurveBucketV2` から `creatorFeeAccrued` フィールドを読み取ります。グラデュエーション後は `fetchRaydiumCpmmBucketV2` を使用して `RaydiumCpmmBucketV2` から `creatorFeeAccrued` を読み取ります。[蓄積したクリエイター手数料の確認](#蓄積したクリエイター手数料の確認)を参照してください。
+アクティブカーブ中は `fetchBondingCurveBucketV2` を使用して `BondingCurveBucketV2` から `creatorFeeAccrued` フィールドを読み取ります。グラデュエーション後は `fetchRaydiumCpmmBucketV2` を使用して `RaydiumCpmmBucketV2` から `creatorFeeAccrued` を読み取ります。[蓄積したクリエイター手数料の確認](#蓄積したクリエイター手数料の確認)および[蓄積したRaydiumクリエイター手数料の確認](#蓄積したraydiumクリエイター手数料の確認)を参照してください。
 
 ### ローンチ後にクリエイター手数料ウォレットを変更できますか？
 

--- a/src/pages/ja/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/ja/smart-contracts/genesis/creator-fees.md
@@ -30,11 +30,11 @@ proficiencyLevel: Intermediate
 created: '04-09-2026'
 updated: '04-13-2026'
 howToSteps:
-  - Set creatorFeeWallet in the launch object when calling createAndRegisterLaunch
-  - After launch, monitor creatorFeeAccrued in the bucket account using fetchBondingCurveBucketV2
-  - Call claimBondingCurveCreatorFeeV2 to collect accrued fees during the active curve
-  - After graduation, call collectRaydiumCpmmFeesWithCreatorFeeV2 to harvest LP fees from the Raydium pool into the Genesis bucket
-  - Call claimRaydiumCreatorFeeV2 to transfer the accumulated bucket balance to the creator wallet
+  - createAndRegisterLaunch の呼び出し時にローンチオブジェクトで creatorFeeWallet を設定します
+  - ローンチ後、fetchBondingCurveBucketV2 を使用してバケットアカウントの creatorFeeAccrued を監視します
+  - アクティブカーブ期間中に claimBondingCurveCreatorFeeV2 を呼び出して発生した手数料を請求します
+  - 卒業後、collectRaydiumCpmmFeesWithCreatorFeeV2 を呼び出して Raydium プールの LP 手数料を Genesis バケットに収集します
+  - claimRaydiumCreatorFeeV2 を呼び出してバケットの累積残高をクリエイターウォレットに転送します
 howToTools:
   - Node.js
   - Umi framework
@@ -82,6 +82,8 @@ faqs:
 このセクションでは、アクティブカーブとグラデュエーション後の両フェーズでクリエイター手数料を設定および請求するための最小限の手順を説明します。
 
 ### クイックリファレンス
+
+この表は、各手数料インストラクションを呼び出すタイミング、必要なアカウント、およびクリエイター手数料ライフサイクルへの影響をまとめたものです。
 
 | インストラクション | 使用タイミング | 必要なアカウント | 出力 / 効果 |
 |---|---|---|---|

--- a/src/pages/ko/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/ko/smart-contracts/genesis/creator-fees.md
@@ -1,15 +1,20 @@
 ---
 title: Genesis 본딩 커브의 창작자 수수료
 metaTitle: Genesis 본딩 커브 창작자 수수료 — 구성 및 청구 | Metaplex
-description: Genesis 본딩 커브 런칭에서 창작자 수수료를 구성하고 활성 커브 중 및 Raydium CPMM 풀로 졸업한 후 누적 수수료를 청구하는 방법.
+description: Genesis 본딩 커브 런칭에서 창작자 수수료를 구성하고, 활성 커브 중 누적 수수료를 청구하며, Raydium CPMM 풀에서 졸업 후 수수료를 수집 및 청구하는 방법.
 keywords:
   - creator fee
   - bonding curve
   - genesis
   - claimBondingCurveCreatorFeeV2
   - claimRaydiumCreatorFeeV2
+  - collectRaydiumCpmmFeesWithCreatorFeeV2
+  - deriveRaydiumPDAsV2
+  - findRaydiumCpmmBucketV2Pda
+  - fetchRaydiumCpmmBucketV2
   - creatorFeeWallet
   - creatorFeeAccrued
+  - RaydiumCpmmBucketV2
   - Raydium CPMM
   - token launch
   - Solana
@@ -23,12 +28,13 @@ programmingLanguage:
   - TypeScript
 proficiencyLevel: Intermediate
 created: '04-09-2026'
-updated: '04-09-2026'
+updated: '04-13-2026'
 howToSteps:
   - Set creatorFeeWallet in the launch object when calling createAndRegisterLaunch
   - After launch, monitor creatorFeeAccrued in the bucket account using fetchBondingCurveBucketV2
   - Call claimBondingCurveCreatorFeeV2 to collect accrued fees during the active curve
-  - After graduation, call claimRaydiumCreatorFeeV2 to collect fees from the Raydium CPMM pool
+  - After graduation, call collectRaydiumCpmmFeesWithCreatorFeeV2 to harvest LP fees from the Raydium pool into the Genesis bucket
+  - Call claimRaydiumCreatorFeeV2 to transfer the accumulated bucket balance to the creator wallet
 howToTools:
   - Node.js
   - Umi framework
@@ -37,13 +43,15 @@ faqs:
   - q: creatorFeeWallet를 설정하지 않으면 기본 창작자 수수료 지갑은 무엇인가요?
     a: 기본값은 런칭 지갑입니다 — createLaunch 호출에 서명한 지갑입니다. 다른 주소로 수수료를 지정하려면 launch 객체에서 creatorFeeWallet을 명시적으로 설정하세요.
   - q: 창작자 수수료는 매 스왑마다 전송되나요?
-    a: 아니요. 창작자 수수료는 각 스왑에서 버킷(creatorFeeAccrued)에 누적되지만 즉시 전송되지는 않습니다. 활성 커브 중에는 claimBondingCurveCreatorFeeV2를 호출하고, 졸업 후에는 claimRaydiumCreatorFeeV2를 호출하여 수수료를 수집하세요.
-  - q: 누구든지 claimBondingCurveCreatorFeeV2를 호출할 수 있나요?
+    a: 아니요. 창작자 수수료는 각 스왑에서 버킷(creatorFeeAccrued)에 누적되지만 즉시 전송되지는 않습니다. 활성 커브 중에는 claimBondingCurveCreatorFeeV2를 호출하세요. 졸업 후에는 collectRaydiumCpmmFeesWithCreatorFeeV2를 호출하여 Raydium 풀에서 LP 수수료를 수집한 다음, claimRaydiumCreatorFeeV2를 호출하여 창작자 지갑으로 전송하세요.
+  - q: 누구든지 claimBondingCurveCreatorFeeV2나 claimRaydiumCreatorFeeV2를 호출할 수 있나요?
     a: 네. 3개의 권한 없는 수수료 명령어는 활성 커브와 졸업 후 단계 모두에 걸쳐 있습니다 — collectRaydiumCpmmFeesWithCreatorFeeV2와 claimBondingCurveCreatorFeeV2(활성 커브), 그리고 claimRaydiumCreatorFeeV2(졸업 후). 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
+  - q: collectRaydiumCpmmFeesWithCreatorFeeV2와 claimRaydiumCreatorFeeV2의 차이점은 무엇인가요?
+    a: collectRaydiumCpmmFeesWithCreatorFeeV2는 Raydium CPMM 풀에서 누적된 LP 거래 수수료를 Genesis RaydiumCpmmBucketV2 버킷으로 수집합니다. claimRaydiumCreatorFeeV2는 버킷에 있는 잔액을 창작자 수수료 지갑으로 전송합니다. 졸업 후 수수료를 완전히 수집하려면 두 단계 모두 필요합니다.
   - q: 첫 번째 구매는 창작자 수수료를 납부하나요?
     a: 아니요. 첫 번째 구매가 구성되어 있으면 프로토콜 스왑 수수료와 창작자 수수료 모두 초기 구매에서 면제됩니다. 이후 모든 스왑에는 일반 창작자 수수료가 적용됩니다.
   - q: 누적된 창작자 수수료를 확인하는 방법은 무엇인가요?
-    a: 활성 커브 중에는 fetchBondingCurveBucketV2를 사용하여 BondingCurveBucketV2에서 creatorFeeAccrued 필드를 읽으세요. 졸업 후에는 fetchRaydiumCpmmBucketV2를 사용하여 RaydiumCpmmBucketV2에서 creatorFeeAccrued를 읽으세요. 누적 창작자 수수료 확인 섹션을 참조하세요.
+    a: 활성 커브 중에는 fetchBondingCurveBucketV2를 사용하여 BondingCurveBucketV2에서 creatorFeeAccrued 필드를 읽으세요. 졸업 후에는 fetchRaydiumCpmmBucketV2를 사용하여 RaydiumCpmmBucketV2에서 creatorFeeAccrued를 읽으세요. 누적 창작자 수수료 확인 및 누적 Raydium 창작자 수수료 확인 섹션을 참조하세요.
   - q: 런칭 후 창작자 수수료 지갑을 변경할 수 있나요?
     a: 아니요. 창작자 수수료 지갑은 커브 생성 시 설정되며 커브가 라이브된 후에는 변경할 수 없습니다.
 ---
@@ -65,7 +73,7 @@ faqs:
 - **구성** — 커브 생성 시 `launch` 객체에서 `creatorFeeWallet`을 설정합니다; 생략하면 런칭 지갑이 기본값
 - **누적** — `creatorFeeAccrued`가 매 스왑에서 증가합니다; 수수료는 스왑당 전송되지 않습니다
 - **활성 커브 청구** — `claimBondingCurveCreatorFeeV2`가 커브가 라이브 중에 누적 수수료를 수집합니다
-- **졸업 후 청구** — `claimRaydiumCreatorFeeV2`가 커브 졸업 후 Raydium CPMM 풀에서 수수료를 수집합니다
+- **졸업 후 청구** — 2단계: `collectRaydiumCpmmFeesWithCreatorFeeV2`가 Raydium 풀에서 LP 수수료를 Genesis 버킷으로 수집한 다음, `claimRaydiumCreatorFeeV2`가 버킷 잔액을 창작자 지갑으로 전송합니다
 
 창작자 수수료가 스왑 가격 책정 및 프로토콜 스왑 수수료와 상호 작용하는 방법은 [운영 이론 — 수수료 구조](/smart-contracts/genesis/bonding-curve-theory#fee-structure)를 참조하세요.
 
@@ -83,19 +91,20 @@ faqs:
 | `collectRaydiumCpmmFeesWithCreatorFeeV2` | 졸업 후 — LP 수수료 수확 | Genesis 계정, Raydium 풀 PDA, Raydium 버킷 PDA | LP 수수료가 Raydium 풀에서 Genesis 버킷으로 이동 |
 | `claimRaydiumCreatorFeeV2` | 졸업 후 — 버킷 잔액 청구 | Genesis 계정, Raydium 버킷 PDA, 베이스/쿼트 민트, 창작자 수수료 지갑 | 버킷 잔액이 창작자 지갑으로 전송 |
 
-**바로 가기:** [런칭 시 구성](#런칭-시-창작자-수수료-구성) · [지갑으로 지정](#특정-지갑으로-창작자-수수료-지정) · [에이전트 PDA](#에이전트-런칭-자동-pda-라우팅) · [첫 번째 구매와 결합](#창작자-수수료와-첫-번째-구매-결합) · [누적 확인](#누적-창작자-수수료-확인) · [커브 중 청구](#활성-커브-중-창작자-수수료-청구) · [졸업 후 청구](#졸업-후-창작자-수수료-청구)
+**바로 가기:** [런칭 시 구성](#런칭-시-창작자-수수료-구성) · [지갑으로 지정](#특정-지갑으로-창작자-수수료-지정) · [에이전트 PDA](#에이전트-런칭--자동-pda-라우팅) · [첫 번째 구매와 결합](#창작자-수수료와-첫-번째-구매-결합) · [누적 확인(커브)](#누적-창작자-수수료-확인) · [커브 중 청구](#활성-커브-중-창작자-수수료-청구) · [Raydium 수수료 확인](#누적-raydium-창작자-수수료-확인) · [Raydium에서 수집](#단계-1--raydium-cpmm-풀에서-수수료-수집) · [졸업 후 청구](#단계-2--창작자-지갑으로-수수료-청구)
 
 1. `createAndRegisterLaunch`를 호출할 때 `launch` 객체에서 `creatorFeeWallet`을 설정합니다
 2. 런칭 후 `bucket.creatorFeeAccrued`를 읽어 누적된 수수료를 모니터링합니다
 3. `claimBondingCurveCreatorFeeV2`를 호출하여 커브가 활성 중에 수수료를 수집합니다
-4. 졸업 후 `claimRaydiumCreatorFeeV2`를 호출하여 Raydium LP 수수료를 수집합니다
+4. 졸업 후 `collectRaydiumCpmmFeesWithCreatorFeeV2`를 호출하여 Raydium 풀에서 LP 수수료를 수집합니다
+5. `claimRaydiumCreatorFeeV2`를 호출하여 버킷 잔액을 창작자 지갑으로 전송합니다
 
 ## 사전 요구 사항
 
 Genesis SDK, 구성된 Umi 인스턴스 및 충전된 Solana 지갑이 필요합니다.
 
 - `@metaplex-foundation/genesis` SDK 설치
-- 키페어 ID로 구성된 Umi 인스턴스 — [Metaplex API를 통한 본딩 커브 런칭](/smart-contracts/genesis/bonding-curve-launch#umi-설정)을 참조하세요
+- 키페어 ID로 구성된 Umi 인스턴스 — [Metaplex API를 통한 본딩 커브 런칭](/smart-contracts/genesis/bonding-curve-launch#umi-setup)을 참조하세요
 - 트랜잭션 수수료를 위한 충전된 Solana 지갑
 
 ## 런칭 시 창작자 수수료 구성
@@ -200,27 +209,194 @@ console.log('Creator fees claimed:', result.signature);
 
 ## 졸업 후 창작자 수수료 청구
 
-본딩 커브가 [졸업](/smart-contracts/genesis/bonding-curve-theory#phase-3-graduated)한 후, 유동성이 Raydium CPMM 풀로 이전되고 LP 거래 활동에서 창작자 수수료가 계속 누적됩니다. `RaydiumCpmmBucketV2` 계정은 `BondingCurveBucketV2`의 것과 유사한 `creatorFeeAccrued` 및 `creatorFeeClaimed` 필드를 노출합니다. 졸업 후 수수료는 `claimRaydiumCreatorFeeV2`로 수집합니다.
+본딩 커브가 [졸업](/smart-contracts/genesis/bonding-curve-theory#phase-3-graduated)한 후, 유동성이 Raydium CPMM 풀로 이전되고 LP 거래 활동에서 창작자 수수료가 계속 누적됩니다. 졸업 후 수수료 수집은 **2단계 프로세스**입니다: 먼저 Raydium 풀에서 누적된 LP 거래 수수료를 Genesis `RaydiumCpmmBucketV2` 버킷으로 수집한 다음, 버킷 잔액을 창작자 지갑으로 청구합니다.
 
-```typescript {% title="claim-raydium-creator-fees.ts" showLineNumbers=true %}
-import { claimRaydiumCreatorFeeV2 } from '@metaplex-foundation/genesis';
+### 누적 Raydium 창작자 수수료 확인
 
-const result = await claimRaydiumCreatorFeeV2(umi, {
+`RaydiumCpmmBucketV2` 계정은 `BondingCurveBucketV2`와 유사한 `creatorFeeAccrued` 및 `creatorFeeClaimed` 필드를 노출합니다. `findRaydiumCpmmBucketV2Pda`와 `fetchRaydiumCpmmBucketV2`를 사용하여 파생 및 조회합니다.
+
+```typescript {% title="check-raydium-fees.ts" showLineNumbers=true %}
+import {
+  findRaydiumCpmmBucketV2Pda,
+  fetchRaydiumCpmmBucketV2,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey } from '@metaplex-foundation/umi';
+
+const genesisAccount = publicKey('YOUR_GENESIS_ACCOUNT_PUBKEY');
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
   genesisAccount,
-  // ... Raydium 풀 계정
-}).sendAndConfirm(umi);
+  bucketIndex: 0,
+});
+
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+const claimable = raydiumBucket.creatorFeeAccrued - raydiumBucket.creatorFeeClaimed;
+console.log('Claimable Raydium creator fees (lamports):', claimable);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+const creatorFeeWallet = isSome(creatorFeeExt) ? creatorFeeExt.value.wallet : null;
+console.log('Creator fee wallet:', creatorFeeWallet?.toString() ?? 'none configured');
 ```
 
 {% callout type="note" %}
-본딩 커브에 해당하는 것과 마찬가지로, `claimRaydiumCreatorFeeV2`는 권한 없이 호출 가능합니다 — 어떤 지갑도 청구를 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송됩니다.
+`raydiumBucket.creatorFeeAccrued`는 Raydium 풀에서 버킷으로 이미 수집된 수수료만 반영합니다. Raydium 풀 자체에 수집되지 않은 LP 수수료가 있을 수 있습니다 — 최종 청구 가능 잔액을 읽기 전에 `collectRaydiumCpmmFeesWithCreatorFeeV2`를 실행하여 버킷으로 이동하세요.
 {% /callout %}
+
+### 단계 1 — Raydium CPMM 풀에서 수수료 수집
+
+`collectRaydiumCpmmFeesWithCreatorFeeV2`는 Raydium CPMM 풀에서 누적된 LP 거래 수수료를 수집하여 `RaydiumCpmmBucketV2` 버킷 서명자의 토큰 계정에 크레딧하고 `creatorFeeAccrued`를 업데이트합니다. 청구 전에 이 단계를 실행해야 합니다 — Raydium에서 수수료가 수집될 때까지 청구할 것이 없습니다.
+
+`deriveRaydiumPDAsV2`를 사용하여 베이스 민트와 버킷 주소에서 필요한 모든 Raydium 풀 계정을 계산합니다. `creatorFee: true`를 전달하여 창작자 수수료 AMM 구성을 선택합니다.
+
+```typescript {% title="collect-raydium-fees.ts" showLineNumbers=true %}
+import {
+  collectRaydiumCpmmFeesWithCreatorFeeV2,
+  deriveRaydiumPDAsV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { publicKey } from '@metaplex-foundation/umi';
+
+const baseMint = publicKey('TOKEN_MINT_PUBKEY');
+const quoteMint = publicKey('So11111111111111111111111111111111111111112'); // wSOL
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+const pdas = deriveRaydiumPDAsV2(umi, baseMint, raydiumBucketPda, {
+  quoteMint,
+  env: 'mainnet', // or 'devnet'
+  creatorFee: true,
+});
+
+await collectRaydiumCpmmFeesWithCreatorFeeV2(umi, {
+  baseMint,
+  quoteMint,
+  genesisAccount,
+  poolState: pdas.poolState,
+  raydiumCpmmBucket: raydiumBucketPda,
+  ammConfig: pdas.ammConfig,
+  poolAuthority: pdas.poolAuthority,
+  baseVault: pdas.baseVault,
+  quoteVault: pdas.quoteVault,
+  raydiumProgram: pdas.raydiumProgram,
+}).sendAndConfirm(umi);
+
+console.log('Raydium LP fees collected into Genesis bucket');
+```
+
+{% callout type="note" %}
+`collectRaydiumCpmmFeesWithCreatorFeeV2`는 권한 없이 호출 가능합니다 — 어떤 지갑도 호출할 수 있습니다. 수집된 수수료는 Genesis 버킷 서명자의 토큰 계정으로 흘러가며, 다음 버킷 조회 시 `creatorFeeAccrued`에 반영됩니다.
+{% /callout %}
+
+### 단계 2 — 창작자 지갑으로 수수료 청구
+
+`claimRaydiumCreatorFeeV2`는 `RaydiumCpmmBucketV2` 버킷에 누적된 잔액을 구성된 창작자 수수료 지갑으로 전송합니다. 수집 후에 실행하거나, 이전 수집에서 버킷에 미청구 잔액이 있는 경우 언제든지 실행합니다.
+
+```typescript {% title="claim-raydium-creator-fees.ts" showLineNumbers=true %}
+import {
+  claimRaydiumCreatorFeeV2,
+  fetchRaydiumCpmmBucketV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey } from '@metaplex-foundation/umi';
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+// 수집 후 다시 조회하여 업데이트된 creatorFeeAccrued를 가져옵니다.
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured on this Raydium bucket');
+const creatorFeeWallet = creatorFeeExt.value.wallet;
+
+await claimRaydiumCreatorFeeV2(umi, {
+  genesisAccount: raydiumBucket.bucket.genesis,
+  bucket: raydiumBucketPda,
+  baseMint: raydiumBucket.bucket.baseMint,
+  quoteMint: raydiumBucket.bucket.quoteMint,
+  creatorFeeWallet,
+}).sendAndConfirm(umi);
+
+console.log('Raydium creator fees claimed to:', creatorFeeWallet.toString());
+```
+
+{% callout type="note" %}
+`claimRaydiumCreatorFeeV2`는 권한 없이 호출 가능합니다 — 어떤 지갑도 청구를 트리거할 수 있지만, SOL(wSOL)은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
+{% /callout %}
+
+### 수집 및 청구 통합 흐름
+
+두 빌더를 체이닝하여 단일 트랜잭션에서 수집과 청구를 수행합니다. 풀에 미수집 수수료가 없고 버킷 잔액도 0인 경우, 무의미한 트랜잭션을 피하기 위해 두 명령어를 모두 건너뜁니다.
+
+```typescript {% title="collect-and-claim-raydium.ts" showLineNumbers=true %}
+import {
+  collectRaydiumCpmmFeesWithCreatorFeeV2,
+  claimRaydiumCreatorFeeV2,
+  deriveRaydiumPDAsV2,
+  fetchRaydiumCpmmBucketV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey, transactionBuilder } from '@metaplex-foundation/umi';
+
+const baseMint = publicKey('TOKEN_MINT_PUBKEY');
+const quoteMint = publicKey('So11111111111111111111111111111111111111112');
+const genesisAccount = publicKey('YOUR_GENESIS_ACCOUNT_PUBKEY');
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured');
+const creatorFeeWallet = creatorFeeExt.value.wallet;
+
+const pdas = deriveRaydiumPDAsV2(umi, baseMint, raydiumBucketPda, {
+  quoteMint,
+  env: 'mainnet', // or 'devnet'
+  creatorFee: true,
+});
+
+await transactionBuilder()
+  .add(collectRaydiumCpmmFeesWithCreatorFeeV2(umi, {
+    baseMint,
+    quoteMint,
+    genesisAccount,
+    poolState: pdas.poolState,
+    raydiumCpmmBucket: raydiumBucketPda,
+    ammConfig: pdas.ammConfig,
+    poolAuthority: pdas.poolAuthority,
+    baseVault: pdas.baseVault,
+    quoteVault: pdas.quoteVault,
+    raydiumProgram: pdas.raydiumProgram,
+  }))
+  .add(claimRaydiumCreatorFeeV2(umi, {
+    genesisAccount,
+    bucket: raydiumBucketPda,
+    baseMint,
+    quoteMint,
+    creatorFeeWallet,
+  }))
+  .sendAndConfirm(umi);
+
+console.log('Raydium creator fees collected and claimed to:', creatorFeeWallet.toString());
+```
 
 ## 참고 사항
 
 다음 주의사항은 수수료 타이밍, 권한 없는 청구, 2단계 졸업 후 흐름 및 첫 번째 구매 수수료 면제에 대해 설명합니다.
 
 - 창작자 수수료는 각 스왑에서 버킷(`creatorFeeAccrued`)에 누적되며 즉시 전송되지 않습니다 — 수수료를 받으려면 청구 명령어를 명시적으로 호출해야 합니다; `creatorFeeClaimed`는 현재까지 청구된 누적 합계를 추적합니다
-- 두 청구 명령어 모두 권한 없이 호출 가능합니다: 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송됩니다
+- `claimBondingCurveCreatorFeeV2`와 `claimRaydiumCreatorFeeV2` 모두 권한 없이 호출 가능합니다: 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송됩니다; `collectRaydiumCpmmFeesWithCreatorFeeV2`도 권한 없이 호출 가능합니다
+- 졸업 후 수수료는 순서대로 두 단계가 필요합니다: `collectRaydiumCpmmFeesWithCreatorFeeV2`(Raydium 풀 → Genesis 버킷으로 수집), 그 다음 `claimRaydiumCreatorFeeV2`(버킷 → 창작자 지갑); 두 단계를 단일 트랜잭션으로 결합할 수 있습니다
+- `creatorFeeAccrued`와 `creatorFeeClaimed`는 `BondingCurveBucketV2`(활성 커브)와 `RaydiumCpmmBucketV2`(졸업 후) 모두에 존재합니다; 각각 `fetchBondingCurveBucketV2`와 `fetchRaydiumCpmmBucketV2`를 사용하세요
 - `creatorFeeWallet`은 설정하지 않으면 런칭 지갑으로 기본 설정됩니다; 커브가 생성된 후에는 변경할 수 없습니다
 - 첫 번째 구매 메커니즘은 지정된 초기 구매에 대해서만 모든 수수료(프로토콜 및 창작자)를 면제합니다; 이후 모든 스왑은 일반 창작자 수수료를 납부합니다
 - 창작자 수수료는 방향(매수 또는 매도)에 관계없이 모든 스왑의 SOL 측면에 적용됩니다; 프로토콜 스왑 수수료와 복합적으로 계산되지 않습니다
@@ -235,11 +411,19 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 창작자 수수료는 매 스왑마다 전송되나요?
 
-아니요. 창작자 수수료는 각 스왑에서 버킷(`creatorFeeAccrued`)에 누적되지만 즉시 전송되지는 않습니다. 활성 커브 중에는 `claimBondingCurveCreatorFeeV2`를 호출하고, 졸업 후에는 `claimRaydiumCreatorFeeV2`를 호출하여 수수료를 수집하세요.
+아니요. 창작자 수수료는 각 스왑에서 버킷(`creatorFeeAccrued`)에 누적되지만 즉시 전송되지는 않습니다. 활성 커브 중에는 `claimBondingCurveCreatorFeeV2`를 호출하세요. 졸업 후에는 `collectRaydiumCpmmFeesWithCreatorFeeV2`를 호출하여 Raydium 풀에서 LP 수수료를 수집한 다음, `claimRaydiumCreatorFeeV2`를 호출하여 창작자 지갑으로 전송하세요.
 
-### 누구든지 `claimBondingCurveCreatorFeeV2`를 호출할 수 있나요?
+### 누구든지 `claimBondingCurveCreatorFeeV2`나 `claimRaydiumCreatorFeeV2`를 호출할 수 있나요?
 
 네. 3개의 권한 없는 수수료 명령어는 활성 커브와 졸업 후 단계 모두에 걸쳐 있습니다 — `collectRaydiumCpmmFeesWithCreatorFeeV2`와 `claimBondingCurveCreatorFeeV2`(활성 커브), 그리고 `claimRaydiumCreatorFeeV2`(졸업 후). 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
+
+### `collectRaydiumCpmmFeesWithCreatorFeeV2`와 `claimRaydiumCreatorFeeV2`의 차이점은 무엇인가요?
+
+`collectRaydiumCpmmFeesWithCreatorFeeV2`는 Raydium CPMM 풀에서 누적된 LP 거래 수수료를 Genesis `RaydiumCpmmBucketV2` 버킷으로 수집합니다 — 이를 통해 버킷의 `creatorFeeAccrued`가 업데이트됩니다. `claimRaydiumCreatorFeeV2`는 해당 버킷 잔액을 창작자 수수료 지갑으로 전송합니다. 청구 전에 수집을 실행해야 합니다 — 수집 없이는 청구할 버킷 잔액이 없습니다.
+
+### Raydium 버킷의 `creatorFeeAccrued`가 풀이 활성인데도 0인 이유는 무엇인가요?
+
+`RaydiumCpmmBucketV2`의 `creatorFeeAccrued`는 `collectRaydiumCpmmFeesWithCreatorFeeV2`를 통해 Raydium에서 Genesis 버킷으로 수집된 수수료만 반영합니다. LP 거래 수수료는 먼저 Raydium 풀 상태 내에 누적됩니다 — 수집 명령어를 실행할 때까지 Genesis 버킷에 나타나지 않습니다.
 
 ### 첫 번째 구매는 창작자 수수료를 납부하나요?
 
@@ -247,7 +431,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 누적된 창작자 수수료를 확인하는 방법은 무엇인가요?
 
-활성 커브 중에는 `fetchBondingCurveBucketV2`를 사용하여 `BondingCurveBucketV2`에서 `creatorFeeAccrued` 필드를 읽으세요. 졸업 후에는 `fetchRaydiumCpmmBucketV2`를 사용하여 `RaydiumCpmmBucketV2`에서 `creatorFeeAccrued`를 읽으세요. [누적 창작자 수수료 확인](#누적-창작자-수수료-확인)을 참조하세요.
+활성 커브 중에는 `fetchBondingCurveBucketV2`를 사용하여 `BondingCurveBucketV2`에서 `creatorFeeAccrued` 필드를 읽으세요. 졸업 후에는 `fetchRaydiumCpmmBucketV2`를 사용하여 `RaydiumCpmmBucketV2`에서 `creatorFeeAccrued`를 읽으세요. [누적 창작자 수수료 확인](#누적-창작자-수수료-확인) 및 [누적 Raydium 창작자 수수료 확인](#누적-raydium-창작자-수수료-확인)을 참조하세요.
 
 ### 런칭 후 창작자 수수료 지갑을 변경할 수 있나요?
 

--- a/src/pages/ko/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/ko/smart-contracts/genesis/creator-fees.md
@@ -39,11 +39,11 @@ faqs:
   - q: 창작자 수수료는 매 스왑마다 전송되나요?
     a: 아니요. 창작자 수수료는 각 스왑에서 버킷(creatorFeeAccrued)에 누적되지만 즉시 전송되지는 않습니다. 활성 커브 중에는 claimBondingCurveCreatorFeeV2를 호출하고, 졸업 후에는 claimRaydiumCreatorFeeV2를 호출하여 수수료를 수집하세요.
   - q: 누구든지 claimBondingCurveCreatorFeeV2를 호출할 수 있나요?
-    a: 네. claimBondingCurveCreatorFeeV2와 claimRaydiumCreatorFeeV2는 모두 권한 없이 호출 가능합니다 — 어떤 지갑도 청구를 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
+    a: 네. 3개의 권한 없는 수수료 명령어는 활성 커브와 졸업 후 단계 모두에 걸쳐 있습니다 — collectRaydiumCpmmFeesWithCreatorFeeV2와 claimBondingCurveCreatorFeeV2(활성 커브), 그리고 claimRaydiumCreatorFeeV2(졸업 후). 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
   - q: 첫 번째 구매는 창작자 수수료를 납부하나요?
     a: 아니요. 첫 번째 구매가 구성되어 있으면 프로토콜 스왑 수수료와 창작자 수수료 모두 초기 구매에서 면제됩니다. 이후 모든 스왑에는 일반 창작자 수수료가 적용됩니다.
   - q: 누적된 창작자 수수료를 확인하는 방법은 무엇인가요?
-    a: Genesis SDK의 fetchBondingCurveBucketV2를 사용하여 버킷 계정에서 creatorFeeAccrued 필드를 읽으세요.
+    a: 활성 커브 중에는 fetchBondingCurveBucketV2를 사용하여 BondingCurveBucketV2에서 creatorFeeAccrued 필드를 읽으세요. 졸업 후에는 fetchRaydiumCpmmBucketV2를 사용하여 RaydiumCpmmBucketV2에서 creatorFeeAccrued를 읽으세요. 누적 창작자 수수료 확인 섹션을 참조하세요.
   - q: 런칭 후 창작자 수수료 지갑을 변경할 수 있나요?
     a: 아니요. 창작자 수수료 지갑은 커브 생성 시 설정되며 커브가 라이브된 후에는 변경할 수 없습니다.
 ---
@@ -71,6 +71,18 @@ faqs:
 
 ## 빠른 시작
 
+이 섹션에서는 활성 커브와 졸업 후 단계 모두에서 창작자 수수료를 구성하고 청구하는 최소 단계를 설명합니다.
+
+### 빠른 참조
+
+| 명령어 | 사용 시기 | 필요한 계정 | 출력 / 효과 |
+|---|---|---|---|
+| `createAndRegisterLaunch`(`creatorFeeWallet` 설정) | 커브 생성 시 | 창작자 지갑, 런칭 서명자 | 버킷에 수수료 지갑 구성 |
+| `fetchBondingCurveBucketV2`(`creatorFeeAccrued` 읽기) | 활성 커브 중 아무 때나 | 버킷 PDA | 현재 누적 수수료 잔액(lamports) |
+| `claimBondingCurveCreatorFeeV2` | 활성 커브 — 누적 수수료 수집 | Genesis 계정, 버킷 PDA, 베이스 민트, 창작자 수수료 지갑 | 누적 SOL이 창작자 지갑으로 전송 |
+| `collectRaydiumCpmmFeesWithCreatorFeeV2` | 졸업 후 — LP 수수료 수확 | Genesis 계정, Raydium 풀 PDA, Raydium 버킷 PDA | LP 수수료가 Raydium 풀에서 Genesis 버킷으로 이동 |
+| `claimRaydiumCreatorFeeV2` | 졸업 후 — 버킷 잔액 청구 | Genesis 계정, Raydium 버킷 PDA, 베이스/쿼트 민트, 창작자 수수료 지갑 | 버킷 잔액이 창작자 지갑으로 전송 |
+
 **바로 가기:** [런칭 시 구성](#런칭-시-창작자-수수료-구성) · [지갑으로 지정](#특정-지갑으로-창작자-수수료-지정) · [에이전트 PDA](#에이전트-런칭-자동-pda-라우팅) · [첫 번째 구매와 결합](#창작자-수수료와-첫-번째-구매-결합) · [누적 확인](#누적-창작자-수수료-확인) · [커브 중 청구](#활성-커브-중-창작자-수수료-청구) · [졸업 후 청구](#졸업-후-창작자-수수료-청구)
 
 1. `createAndRegisterLaunch`를 호출할 때 `launch` 객체에서 `creatorFeeWallet`을 설정합니다
@@ -79,6 +91,8 @@ faqs:
 4. 졸업 후 `claimRaydiumCreatorFeeV2`를 호출하여 Raydium LP 수수료를 수집합니다
 
 ## 사전 요구 사항
+
+Genesis SDK, 구성된 Umi 인스턴스 및 충전된 Solana 지갑이 필요합니다.
 
 - `@metaplex-foundation/genesis` SDK 설치
 - 키페어 ID로 구성된 Umi 인스턴스 — [Metaplex API를 통한 본딩 커브 런칭](/smart-contracts/genesis/bonding-curve-launch#umi-설정)을 참조하세요
@@ -203,6 +217,8 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ## 참고 사항
 
+다음 주의사항은 수수료 타이밍, 권한 없는 청구, 2단계 졸업 후 흐름 및 첫 번째 구매 수수료 면제에 대해 설명합니다.
+
 - 창작자 수수료는 각 스왑에서 버킷(`creatorFeeAccrued`)에 누적되며 즉시 전송되지 않습니다 — 수수료를 받으려면 청구 명령어를 명시적으로 호출해야 합니다; `creatorFeeClaimed`는 현재까지 청구된 누적 합계를 추적합니다
 - 두 청구 명령어 모두 권한 없이 호출 가능합니다: 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송됩니다
 - `creatorFeeWallet`은 설정하지 않으면 런칭 지갑으로 기본 설정됩니다; 커브가 생성된 후에는 변경할 수 없습니다
@@ -223,7 +239,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 누구든지 `claimBondingCurveCreatorFeeV2`를 호출할 수 있나요?
 
-네. `claimBondingCurveCreatorFeeV2`와 `claimRaydiumCreatorFeeV2`는 모두 권한 없이 호출 가능합니다 — 어떤 지갑도 청구를 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
+네. 3개의 권한 없는 수수료 명령어는 활성 커브와 졸업 후 단계 모두에 걸쳐 있습니다 — `collectRaydiumCpmmFeesWithCreatorFeeV2`와 `claimBondingCurveCreatorFeeV2`(활성 커브), 그리고 `claimRaydiumCreatorFeeV2`(졸업 후). 어떤 지갑도 트리거할 수 있지만 SOL은 항상 구성된 창작자 수수료 지갑으로 전송되며 호출자에게는 전송되지 않습니다.
 
 ### 첫 번째 구매는 창작자 수수료를 납부하나요?
 
@@ -231,7 +247,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 누적된 창작자 수수료를 확인하는 방법은 무엇인가요?
 
-`fetchBondingCurveBucketV2`를 사용하여 버킷 계정에서 `creatorFeeAccrued` 필드를 읽으세요. [누적 창작자 수수료 확인](#누적-창작자-수수료-확인)을 참조하세요.
+활성 커브 중에는 `fetchBondingCurveBucketV2`를 사용하여 `BondingCurveBucketV2`에서 `creatorFeeAccrued` 필드를 읽으세요. 졸업 후에는 `fetchRaydiumCpmmBucketV2`를 사용하여 `RaydiumCpmmBucketV2`에서 `creatorFeeAccrued`를 읽으세요. [누적 창작자 수수료 확인](#누적-창작자-수수료-확인)을 참조하세요.
 
 ### 런칭 후 창작자 수수료 지갑을 변경할 수 있나요?
 

--- a/src/pages/ko/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/ko/smart-contracts/genesis/creator-fees.md
@@ -30,11 +30,11 @@ proficiencyLevel: Intermediate
 created: '04-09-2026'
 updated: '04-13-2026'
 howToSteps:
-  - Set creatorFeeWallet in the launch object when calling createAndRegisterLaunch
-  - After launch, monitor creatorFeeAccrued in the bucket account using fetchBondingCurveBucketV2
-  - Call claimBondingCurveCreatorFeeV2 to collect accrued fees during the active curve
-  - After graduation, call collectRaydiumCpmmFeesWithCreatorFeeV2 to harvest LP fees from the Raydium pool into the Genesis bucket
-  - Call claimRaydiumCreatorFeeV2 to transfer the accumulated bucket balance to the creator wallet
+  - createAndRegisterLaunch 호출 시 런치 객체에 creatorFeeWallet을 설정합니다
+  - 런치 후 fetchBondingCurveBucketV2를 사용하여 버킷 계정의 creatorFeeAccrued를 모니터링합니다
+  - 활성 커브 기간 중 claimBondingCurveCreatorFeeV2를 호출하여 발생한 수수료를 수령합니다
+  - 졸업 후 collectRaydiumCpmmFeesWithCreatorFeeV2를 호출하여 Raydium 풀의 LP 수수료를 Genesis 버킷으로 수확합니다
+  - claimRaydiumCreatorFeeV2를 호출하여 축적된 버킷 잔액을 크리에이터 지갑으로 전송합니다
 howToTools:
   - Node.js
   - Umi framework
@@ -82,6 +82,8 @@ faqs:
 이 섹션에서는 활성 커브와 졸업 후 단계 모두에서 창작자 수수료를 구성하고 청구하는 최소 단계를 설명합니다.
 
 ### 빠른 참조
+
+이 표는 각 수수료 명령어를 호출하는 시기, 필요한 계정, 그리고 창작자 수수료 수명 주기에 미치는 영향을 요약합니다.
 
 | 명령어 | 사용 시기 | 필요한 계정 | 출력 / 효과 |
 |---|---|---|---|

--- a/src/pages/zh/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/zh/smart-contracts/genesis/creator-fees.md
@@ -30,11 +30,11 @@ proficiencyLevel: Intermediate
 created: '04-09-2026'
 updated: '04-13-2026'
 howToSteps:
-  - Set creatorFeeWallet in the launch object when calling createAndRegisterLaunch
-  - After launch, monitor creatorFeeAccrued in the bucket account using fetchBondingCurveBucketV2
-  - Call claimBondingCurveCreatorFeeV2 to collect accrued fees during the active curve
-  - After graduation, call collectRaydiumCpmmFeesWithCreatorFeeV2 to harvest LP fees from the Raydium pool into the Genesis bucket
-  - Call claimRaydiumCreatorFeeV2 to transfer the accumulated bucket balance to the creator wallet
+  - 调用 createAndRegisterLaunch 时在启动对象中设置 creatorFeeWallet
+  - 启动后使用 fetchBondingCurveBucketV2 监控桶账户中的 creatorFeeAccrued
+  - 在活跃曲线期间调用 claimBondingCurveCreatorFeeV2 领取已累积的手续费
+  - 毕业后调用 collectRaydiumCpmmFeesWithCreatorFeeV2 将 Raydium 池中的 LP 手续费收割到 Genesis 桶中
+  - 调用 claimRaydiumCreatorFeeV2 将桶中累积的余额转入创作者钱包
 howToTools:
   - Node.js
   - Umi framework
@@ -82,6 +82,8 @@ faqs:
 本节介绍在活跃曲线和毕业后两个阶段配置和认领创作者费的最少步骤。
 
 ### 快速参考
+
+下表汇总了每条费用指令的调用时机、所需账户及其对创作者费生命周期的影响。
 
 | 指令 | 使用时机 | 必需账户 | 输出 / 效果 |
 |---|---|---|---|

--- a/src/pages/zh/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/zh/smart-contracts/genesis/creator-fees.md
@@ -39,11 +39,11 @@ faqs:
   - q: 创作者费是在每次兑换时转账的吗？
     a: 不是。创作者费在每次兑换时累积到 bucket 中（creatorFeeAccrued），不会立即转账。在活跃曲线期间调用 claimBondingCurveCreatorFeeV2 认领，毕业后调用 claimRaydiumCreatorFeeV2 认领。
   - q: 任何人都可以调用 claimBondingCurveCreatorFeeV2 吗？
-    a: 是的。claimBondingCurveCreatorFeeV2 和 claimRaydiumCreatorFeeV2 都是无需许可的——任何钱包都可以触发认领，但 SOL 始终发送到配置的创作者费钱包，而非调用方。
+    a: 是的。三条无需许可的费用指令横跨活跃曲线和毕业后两个阶段——collectRaydiumCpmmFeesWithCreatorFeeV2 和 claimBondingCurveCreatorFeeV2（活跃曲线）以及 claimRaydiumCreatorFeeV2（毕业后）。任何钱包都可以触发，但 SOL 始终发送到配置的创作者费钱包，而非调用方。
   - q: 首次购买需要支付创作者费吗？
     a: 不需要。配置首次购买时，协议兑换费和创作者费均对该一次性初始购买豁免。之后所有兑换正常支付创作者费。
   - q: 如何检查已累积了多少创作者费？
-    a: 使用 Genesis SDK 的 fetchBondingCurveBucketV2 从 bucket 账户读取 creatorFeeAccrued 字段。
+    a: 活跃曲线期间，使用 fetchBondingCurveBucketV2 从 BondingCurveBucketV2 读取 creatorFeeAccrued 字段。毕业后，使用 fetchRaydiumCpmmBucketV2 从 RaydiumCpmmBucketV2 读取 creatorFeeAccrued。请参阅检查累积的创作者费和检查累积的 Raydium 创作者费部分。
   - q: 发行后可以更改创作者费钱包吗？
     a: 不可以。创作者费钱包在曲线创建时设定，曲线上线后无法更改。
 ---
@@ -71,6 +71,18 @@ faqs:
 
 ## 快速开始
 
+本节介绍在活跃曲线和毕业后两个阶段配置和认领创作者费的最少步骤。
+
+### 快速参考
+
+| 指令 | 使用时机 | 必需账户 | 输出 / 效果 |
+|---|---|---|---|
+| `createAndRegisterLaunch`（设置 `creatorFeeWallet`） | 曲线创建时 | 创作者钱包、发行签名者 | 在 bucket 上配置费用钱包 |
+| `fetchBondingCurveBucketV2`（读取 `creatorFeeAccrued`） | 活跃曲线期间任何时候 | Bucket PDA | 当前累积费用余额（lamports） |
+| `claimBondingCurveCreatorFeeV2` | 活跃曲线——收取累积费用 | Genesis 账户、bucket PDA、base mint、创作者费钱包 | 累积 SOL 转移到创作者钱包 |
+| `collectRaydiumCpmmFeesWithCreatorFeeV2` | 毕业后——收割 LP 费用 | Genesis 账户、Raydium 池 PDA、Raydium bucket PDA | LP 费用从 Raydium 池移至 Genesis bucket |
+| `claimRaydiumCreatorFeeV2` | 毕业后——认领 bucket 余额 | Genesis 账户、Raydium bucket PDA、base/quote mint、创作者费钱包 | Bucket 余额转移到创作者钱包 |
+
 **跳转至：** [发行时配置](#configuring-a-creator-fee-at-launch) · [重定向到钱包](#redirecting-creator-fees-to-a-specific-wallet) · [Agent PDA](#agent-launches-automatic-pda-routing) · [与首次购买组合](#combining-creator-fees-with-a-first-buy) · [检查累积费用](#checking-accrued-creator-fees) · [活跃曲线期间认领](#claiming-creator-fees-during-the-active-curve) · [毕业后认领](#claiming-creator-fees-after-graduation)
 
 1. 调用 `createAndRegisterLaunch` 时在 `launch` 对象中设置 `creatorFeeWallet`
@@ -79,6 +91,8 @@ faqs:
 4. 毕业后调用 `claimRaydiumCreatorFeeV2` 收取 Raydium LP 费用
 
 ## 前置条件
+
+您需要 Genesis SDK、已配置的 Umi 实例和已充值的 Solana 钱包。
 
 - 已安装 `@metaplex-foundation/genesis` SDK
 - 配置了密钥对身份的 Umi 实例——详见[通过 Metaplex API 发行联合曲线](/smart-contracts/genesis/bonding-curve-launch#umi-setup)
@@ -203,6 +217,8 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ## 注意事项
 
+以下注意事项涵盖费用时机、无需许可的认领、两步毕业后流程以及首次购买费用豁免。
+
 - 创作者费在每次兑换时累积到 bucket（`creatorFeeAccrued`），不会立即转账——需显式调用认领指令才能收取；`creatorFeeClaimed` 追踪迄今累积认领的总额
 - 两个认领指令均无需许可：任何钱包都可以触发，但 SOL 始终流向配置的创作者费钱包，而非调用方
 - `creatorFeeWallet` 未设置时默认为发行钱包；曲线创建后无法更改
@@ -223,7 +239,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 任何人都可以调用 `claimBondingCurveCreatorFeeV2` 吗？
 
-是的。`claimBondingCurveCreatorFeeV2` 和 `claimRaydiumCreatorFeeV2` 都是无需许可的——任何钱包都可以触发认领，但 SOL 始终发送到配置的创作者费钱包，而非调用方。
+是的。三条无需许可的费用指令横跨活跃曲线和毕业后两个阶段——`collectRaydiumCpmmFeesWithCreatorFeeV2` 和 `claimBondingCurveCreatorFeeV2`（活跃曲线）以及 `claimRaydiumCreatorFeeV2`（毕业后）。任何钱包都可以触发，但 SOL 始终发送到配置的创作者费钱包，而非调用方。
 
 ### 首次购买需要支付创作者费吗？
 
@@ -231,7 +247,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 如何检查已累积了多少创作者费？
 
-使用 `fetchBondingCurveBucketV2` 从 bucket 账户读取 `creatorFeeAccrued` 字段。详见[检查累积的创作者费](#checking-accrued-creator-fees)。
+活跃曲线期间，使用 `fetchBondingCurveBucketV2` 从 `BondingCurveBucketV2` 读取 `creatorFeeAccrued` 字段。毕业后，使用 `fetchRaydiumCpmmBucketV2` 从 `RaydiumCpmmBucketV2` 读取 `creatorFeeAccrued`。详见[检查累积的创作者费](#checking-accrued-creator-fees)。
 
 ### 发行后可以更改创作者费钱包吗？
 

--- a/src/pages/zh/smart-contracts/genesis/creator-fees.md
+++ b/src/pages/zh/smart-contracts/genesis/creator-fees.md
@@ -1,15 +1,20 @@
 ---
 title: Genesis 联合曲线创作者费
 metaTitle: Genesis 联合曲线创作者费——配置与认领 | Metaplex
-description: 如何在 Genesis 联合曲线发行中配置创作者费，以及在活跃曲线期间和毕业到 Raydium CPMM 池后认领累积的费用。
+description: 如何在 Genesis 联合曲线发行中配置创作者费，在活跃曲线期间认领累积费用，以及从 Raydium CPMM 池收集和认领毕业后费用。
 keywords:
   - creator fee
   - bonding curve
   - genesis
   - claimBondingCurveCreatorFeeV2
   - claimRaydiumCreatorFeeV2
+  - collectRaydiumCpmmFeesWithCreatorFeeV2
+  - deriveRaydiumPDAsV2
+  - findRaydiumCpmmBucketV2Pda
+  - fetchRaydiumCpmmBucketV2
   - creatorFeeWallet
   - creatorFeeAccrued
+  - RaydiumCpmmBucketV2
   - Raydium CPMM
   - token launch
   - Solana
@@ -23,12 +28,13 @@ programmingLanguage:
   - TypeScript
 proficiencyLevel: Intermediate
 created: '04-09-2026'
-updated: '04-09-2026'
+updated: '04-13-2026'
 howToSteps:
   - Set creatorFeeWallet in the launch object when calling createAndRegisterLaunch
   - After launch, monitor creatorFeeAccrued in the bucket account using fetchBondingCurveBucketV2
   - Call claimBondingCurveCreatorFeeV2 to collect accrued fees during the active curve
-  - After graduation, call claimRaydiumCreatorFeeV2 to collect fees from the Raydium CPMM pool
+  - After graduation, call collectRaydiumCpmmFeesWithCreatorFeeV2 to harvest LP fees from the Raydium pool into the Genesis bucket
+  - Call claimRaydiumCreatorFeeV2 to transfer the accumulated bucket balance to the creator wallet
 howToTools:
   - Node.js
   - Umi framework
@@ -37,9 +43,11 @@ faqs:
   - q: 未设置 creatorFeeWallet 时默认的创作者费钱包是什么？
     a: 默认是发行钱包——签署 createLaunch 调用的钱包。在 launch 对象中显式设置 creatorFeeWallet 可将费用重定向到任何其他地址。
   - q: 创作者费是在每次兑换时转账的吗？
-    a: 不是。创作者费在每次兑换时累积到 bucket 中（creatorFeeAccrued），不会立即转账。在活跃曲线期间调用 claimBondingCurveCreatorFeeV2 认领，毕业后调用 claimRaydiumCreatorFeeV2 认领。
-  - q: 任何人都可以调用 claimBondingCurveCreatorFeeV2 吗？
+    a: 不是。创作者费在每次兑换时累积到 bucket 中（creatorFeeAccrued），不会立即转账。在活跃曲线期间调用 claimBondingCurveCreatorFeeV2 认领。毕业后调用 collectRaydiumCpmmFeesWithCreatorFeeV2 从 Raydium 池收集 LP 费用，然后调用 claimRaydiumCreatorFeeV2 转移到创作者钱包。
+  - q: 任何人都可以调用 claimBondingCurveCreatorFeeV2 或 claimRaydiumCreatorFeeV2 吗？
     a: 是的。三条无需许可的费用指令横跨活跃曲线和毕业后两个阶段——collectRaydiumCpmmFeesWithCreatorFeeV2 和 claimBondingCurveCreatorFeeV2（活跃曲线）以及 claimRaydiumCreatorFeeV2（毕业后）。任何钱包都可以触发，但 SOL 始终发送到配置的创作者费钱包，而非调用方。
+  - q: collectRaydiumCpmmFeesWithCreatorFeeV2 和 claimRaydiumCreatorFeeV2 有什么区别？
+    a: collectRaydiumCpmmFeesWithCreatorFeeV2 从 Raydium CPMM 池中收集累积的 LP 交易费用到 Genesis RaydiumCpmmBucketV2 bucket。claimRaydiumCreatorFeeV2 将 bucket 中的余额转移到创作者费钱包。要完整收取毕业后费用，两个步骤都是必需的。
   - q: 首次购买需要支付创作者费吗？
     a: 不需要。配置首次购买时，协议兑换费和创作者费均对该一次性初始购买豁免。之后所有兑换正常支付创作者费。
   - q: 如何检查已累积了多少创作者费？
@@ -65,7 +73,7 @@ faqs:
 - **配置** — 在曲线创建时的 `launch` 对象中设置 `creatorFeeWallet`；省略时默认为发行钱包
 - **累积** — `creatorFeeAccrued` 在每次兑换时增加；费用不按次转账
 - **活跃曲线认领** — `claimBondingCurveCreatorFeeV2` 在曲线活跃时收取累积费用
-- **毕业后认领** — `claimRaydiumCreatorFeeV2` 在曲线毕业后从 Raydium CPMM 池收取费用
+- **毕业后认领** — 两步流程：`collectRaydiumCpmmFeesWithCreatorFeeV2` 从 Raydium 池收集 LP 费用到 Genesis bucket，然后 `claimRaydiumCreatorFeeV2` 将 bucket 余额转移到创作者钱包
 
 关于创作者费如何与兑换定价和协议兑换费交互，请参阅[运作原理——手续费结构](/smart-contracts/genesis/bonding-curve-theory#fee-structure)。
 
@@ -83,12 +91,13 @@ faqs:
 | `collectRaydiumCpmmFeesWithCreatorFeeV2` | 毕业后——收割 LP 费用 | Genesis 账户、Raydium 池 PDA、Raydium bucket PDA | LP 费用从 Raydium 池移至 Genesis bucket |
 | `claimRaydiumCreatorFeeV2` | 毕业后——认领 bucket 余额 | Genesis 账户、Raydium bucket PDA、base/quote mint、创作者费钱包 | Bucket 余额转移到创作者钱包 |
 
-**跳转至：** [发行时配置](#configuring-a-creator-fee-at-launch) · [重定向到钱包](#redirecting-creator-fees-to-a-specific-wallet) · [Agent PDA](#agent-launches-automatic-pda-routing) · [与首次购买组合](#combining-creator-fees-with-a-first-buy) · [检查累积费用](#checking-accrued-creator-fees) · [活跃曲线期间认领](#claiming-creator-fees-during-the-active-curve) · [毕业后认领](#claiming-creator-fees-after-graduation)
+**跳转至：** [发行时配置](#发行时配置创作者费) · [重定向到钱包](#将创作者费重定向到特定钱包) · [Agent PDA](#agent-发行自动-pda-路由) · [与首次购买组合](#将创作者费与首次购买组合) · [检查累积费用（曲线）](#检查累积的创作者费) · [活跃曲线期间认领](#在活跃曲线期间认领创作者费) · [检查 Raydium 费用](#检查累积的-raydium-创作者费) · [从 Raydium 收集](#步骤-1--从-raydium-cpmm-池收集费用) · [毕业后认领](#步骤-2--认领费用到创作者钱包)
 
 1. 调用 `createAndRegisterLaunch` 时在 `launch` 对象中设置 `creatorFeeWallet`
 2. 发行后读取 `bucket.creatorFeeAccrued` 监控累积费用
 3. 调用 `claimBondingCurveCreatorFeeV2` 在曲线活跃时收取费用
-4. 毕业后调用 `claimRaydiumCreatorFeeV2` 收取 Raydium LP 费用
+4. 毕业后调用 `collectRaydiumCpmmFeesWithCreatorFeeV2` 从 Raydium 池收集 LP 费用
+5. 调用 `claimRaydiumCreatorFeeV2` 将 bucket 余额转移到创作者钱包
 
 ## 前置条件
 
@@ -138,7 +147,7 @@ const result = await createAndRegisterLaunch(umi, {}, {
 ```typescript {% title="launch-with-fee-and-first-buy.ts" %}
 launch: {
   creatorFeeWallet: 'FeeRecipientWalletAddress...',
-  firstBuyAmount: 0.5, // 0.5 SOL, fee-free for the first buyer
+  firstBuyAmount: 0.5, // 0.5 SOL，首次购买者免费
 },
 ```
 
@@ -165,7 +174,7 @@ const bucket = await fetchBondingCurveBucketV2(umi, bucketPda);
 console.log('Creator fees accrued (lamports):', bucket.creatorFeeAccrued);
 console.log('Creator fees claimed to date (lamports):', bucket.creatorFeeClaimed);
 
-// Read the configured creator fee wallet from the bucket extension
+// 从 bucket 扩展中读取配置的创作者费钱包
 const creatorFeeExt = bucket.extensions.creatorFee;
 const creatorFeeWallet = isSome(creatorFeeExt) ? creatorFeeExt.value.wallet : null;
 console.log('Creator fee wallet:', creatorFeeWallet?.toString() ?? 'none configured');
@@ -179,7 +188,7 @@ console.log('Creator fee wallet:', creatorFeeWallet?.toString() ?? 'none configu
 import { claimBondingCurveCreatorFeeV2 } from '@metaplex-foundation/genesis';
 import { isSome } from '@metaplex-foundation/umi';
 
-// Read the creator fee wallet from the bucket extension before claiming.
+// 认领前从 bucket 扩展读取创作者费钱包。
 const creatorFeeExt = bucket.extensions.creatorFee;
 if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured on this bucket');
 const creatorFeeWallet = creatorFeeExt.value.wallet;
@@ -200,27 +209,194 @@ console.log('Creator fees claimed:', result.signature);
 
 ## 毕业后认领创作者费
 
-联合曲线[毕业](/smart-contracts/genesis/bonding-curve-theory#phase-3-graduated)后，流动性迁移到 Raydium CPMM 池，创作者费继续从 LP 交易活动中累积。`RaydiumCpmmBucketV2` 账户暴露了类似于 `BondingCurveBucketV2` 的 `creatorFeeAccrued` 和 `creatorFeeClaimed` 字段。使用 `claimRaydiumCreatorFeeV2` 收取毕业后的费用。
+联合曲线[毕业](/smart-contracts/genesis/bonding-curve-theory#phase-3-graduated)后，流动性迁移到 Raydium CPMM 池，创作者费继续从 LP 交易活动中累积。毕业后费用收取是一个**两步流程**：首先从 Raydium 池收集累积的 LP 交易费用到 Genesis `RaydiumCpmmBucketV2` bucket，然后认领 bucket 余额到创作者钱包。
 
-```typescript {% title="claim-raydium-creator-fees.ts" showLineNumbers=true %}
-import { claimRaydiumCreatorFeeV2 } from '@metaplex-foundation/genesis';
+### 检查累积的 Raydium 创作者费
 
-const result = await claimRaydiumCreatorFeeV2(umi, {
+`RaydiumCpmmBucketV2` 账户暴露了类似于 `BondingCurveBucketV2` 的 `creatorFeeAccrued` 和 `creatorFeeClaimed` 字段。使用 `findRaydiumCpmmBucketV2Pda` 和 `fetchRaydiumCpmmBucketV2` 进行派生和获取。
+
+```typescript {% title="check-raydium-fees.ts" showLineNumbers=true %}
+import {
+  findRaydiumCpmmBucketV2Pda,
+  fetchRaydiumCpmmBucketV2,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey } from '@metaplex-foundation/umi';
+
+const genesisAccount = publicKey('YOUR_GENESIS_ACCOUNT_PUBKEY');
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
   genesisAccount,
-  // ... Raydium pool accounts
-}).sendAndConfirm(umi);
+  bucketIndex: 0,
+});
+
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+const claimable = raydiumBucket.creatorFeeAccrued - raydiumBucket.creatorFeeClaimed;
+console.log('Claimable Raydium creator fees (lamports):', claimable);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+const creatorFeeWallet = isSome(creatorFeeExt) ? creatorFeeExt.value.wallet : null;
+console.log('Creator fee wallet:', creatorFeeWallet?.toString() ?? 'none configured');
 ```
 
 {% callout type="note" %}
-与联合曲线对应物一样，`claimRaydiumCreatorFeeV2` 是无需许可的——任何钱包都可以触发认领，但 SOL 始终发送到配置的创作者费钱包。
+`raydiumBucket.creatorFeeAccrued` 仅反映已从 Raydium 池收集到 bucket 中的费用。Raydium 池本身可能持有额外的未收集 LP 费用——在读取最终可认领余额之前，运行 `collectRaydiumCpmmFeesWithCreatorFeeV2` 将其移至 bucket。
 {% /callout %}
+
+### 步骤 1 — 从 Raydium CPMM 池收集费用
+
+`collectRaydiumCpmmFeesWithCreatorFeeV2` 从 Raydium CPMM 池收集累积的 LP 交易费用，将其记入 `RaydiumCpmmBucketV2` bucket 签名者的代币账户，并更新 `creatorFeeAccrued`。必须在认领之前运行此步骤——在从 Raydium 收集费用之前，没有可认领的内容。
+
+使用 `deriveRaydiumPDAsV2` 从 base mint 和 bucket 地址计算所有必需的 Raydium 池账户。传递 `creatorFee: true` 以选择创作者费 AMM 配置。
+
+```typescript {% title="collect-raydium-fees.ts" showLineNumbers=true %}
+import {
+  collectRaydiumCpmmFeesWithCreatorFeeV2,
+  deriveRaydiumPDAsV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { publicKey } from '@metaplex-foundation/umi';
+
+const baseMint = publicKey('TOKEN_MINT_PUBKEY');
+const quoteMint = publicKey('So11111111111111111111111111111111111111112'); // wSOL
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+const pdas = deriveRaydiumPDAsV2(umi, baseMint, raydiumBucketPda, {
+  quoteMint,
+  env: 'mainnet', // or 'devnet'
+  creatorFee: true,
+});
+
+await collectRaydiumCpmmFeesWithCreatorFeeV2(umi, {
+  baseMint,
+  quoteMint,
+  genesisAccount,
+  poolState: pdas.poolState,
+  raydiumCpmmBucket: raydiumBucketPda,
+  ammConfig: pdas.ammConfig,
+  poolAuthority: pdas.poolAuthority,
+  baseVault: pdas.baseVault,
+  quoteVault: pdas.quoteVault,
+  raydiumProgram: pdas.raydiumProgram,
+}).sendAndConfirm(umi);
+
+console.log('Raydium LP fees collected into Genesis bucket');
+```
+
+{% callout type="note" %}
+`collectRaydiumCpmmFeesWithCreatorFeeV2` 是无需许可的——任何钱包都可以调用。收集的费用流入 Genesis bucket 签名者的代币账户，并在下次 bucket 获取时反映在 `creatorFeeAccrued` 中。
+{% /callout %}
+
+### 步骤 2 — 认领费用到创作者钱包
+
+`claimRaydiumCreatorFeeV2` 将 `RaydiumCpmmBucketV2` bucket 中累积的余额转移到配置的创作者费钱包。在收集后运行，或在 bucket 持有来自先前收集的未认领余额时随时运行。
+
+```typescript {% title="claim-raydium-creator-fees.ts" showLineNumbers=true %}
+import {
+  claimRaydiumCreatorFeeV2,
+  fetchRaydiumCpmmBucketV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey } from '@metaplex-foundation/umi';
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+// 收集后重新获取以取得更新的 creatorFeeAccrued。
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured on this Raydium bucket');
+const creatorFeeWallet = creatorFeeExt.value.wallet;
+
+await claimRaydiumCreatorFeeV2(umi, {
+  genesisAccount: raydiumBucket.bucket.genesis,
+  bucket: raydiumBucketPda,
+  baseMint: raydiumBucket.bucket.baseMint,
+  quoteMint: raydiumBucket.bucket.quoteMint,
+  creatorFeeWallet,
+}).sendAndConfirm(umi);
+
+console.log('Raydium creator fees claimed to:', creatorFeeWallet.toString());
+```
+
+{% callout type="note" %}
+`claimRaydiumCreatorFeeV2` 是无需许可的——任何钱包都可以触发认领，但 SOL（作为 wSOL）始终发送到配置的创作者费钱包，而非调用方。
+{% /callout %}
+
+### 收集与认领合并流程
+
+将两个构建器链式组合在单个交易中完成收集和认领。如果池中没有未收集的费用且 bucket 余额为零，请跳过两条指令以避免无效交易。
+
+```typescript {% title="collect-and-claim-raydium.ts" showLineNumbers=true %}
+import {
+  collectRaydiumCpmmFeesWithCreatorFeeV2,
+  claimRaydiumCreatorFeeV2,
+  deriveRaydiumPDAsV2,
+  fetchRaydiumCpmmBucketV2,
+  findRaydiumCpmmBucketV2Pda,
+} from '@metaplex-foundation/genesis';
+import { isSome, publicKey, transactionBuilder } from '@metaplex-foundation/umi';
+
+const baseMint = publicKey('TOKEN_MINT_PUBKEY');
+const quoteMint = publicKey('So11111111111111111111111111111111111111112');
+const genesisAccount = publicKey('YOUR_GENESIS_ACCOUNT_PUBKEY');
+
+const [raydiumBucketPda] = findRaydiumCpmmBucketV2Pda(umi, {
+  genesisAccount,
+  bucketIndex: 0,
+});
+
+const raydiumBucket = await fetchRaydiumCpmmBucketV2(umi, raydiumBucketPda);
+
+const creatorFeeExt = raydiumBucket.extensions.creatorFee;
+if (!isSome(creatorFeeExt)) throw new Error('No creator fee configured');
+const creatorFeeWallet = creatorFeeExt.value.wallet;
+
+const pdas = deriveRaydiumPDAsV2(umi, baseMint, raydiumBucketPda, {
+  quoteMint,
+  env: 'mainnet', // or 'devnet'
+  creatorFee: true,
+});
+
+await transactionBuilder()
+  .add(collectRaydiumCpmmFeesWithCreatorFeeV2(umi, {
+    baseMint,
+    quoteMint,
+    genesisAccount,
+    poolState: pdas.poolState,
+    raydiumCpmmBucket: raydiumBucketPda,
+    ammConfig: pdas.ammConfig,
+    poolAuthority: pdas.poolAuthority,
+    baseVault: pdas.baseVault,
+    quoteVault: pdas.quoteVault,
+    raydiumProgram: pdas.raydiumProgram,
+  }))
+  .add(claimRaydiumCreatorFeeV2(umi, {
+    genesisAccount,
+    bucket: raydiumBucketPda,
+    baseMint,
+    quoteMint,
+    creatorFeeWallet,
+  }))
+  .sendAndConfirm(umi);
+
+console.log('Raydium creator fees collected and claimed to:', creatorFeeWallet.toString());
+```
 
 ## 注意事项
 
 以下注意事项涵盖费用时机、无需许可的认领、两步毕业后流程以及首次购买费用豁免。
 
 - 创作者费在每次兑换时累积到 bucket（`creatorFeeAccrued`），不会立即转账——需显式调用认领指令才能收取；`creatorFeeClaimed` 追踪迄今累积认领的总额
-- 两个认领指令均无需许可：任何钱包都可以触发，但 SOL 始终流向配置的创作者费钱包，而非调用方
+- `claimBondingCurveCreatorFeeV2` 和 `claimRaydiumCreatorFeeV2` 均无需许可：任何钱包都可以触发，但 SOL 始终流向配置的创作者费钱包，而非调用方；`collectRaydiumCpmmFeesWithCreatorFeeV2` 也是无需许可的
+- 毕业后费用需要按顺序两个步骤：`collectRaydiumCpmmFeesWithCreatorFeeV2`（从 Raydium 池收集 → Genesis bucket），然后 `claimRaydiumCreatorFeeV2`（bucket → 创作者钱包）；两者可合并到单个交易中
+- `creatorFeeAccrued` 和 `creatorFeeClaimed` 同时存在于 `BondingCurveBucketV2`（活跃曲线）和 `RaydiumCpmmBucketV2`（毕业后）上；分别使用 `fetchBondingCurveBucketV2` 和 `fetchRaydiumCpmmBucketV2`
 - `creatorFeeWallet` 未设置时默认为发行钱包；曲线创建后无法更改
 - 首次购买机制仅对指定的初始购买豁免所有费用（协议费和创作者费）；之后所有兑换正常收取创作者费
 - 创作者费应用于每次兑换的 SOL 侧，无论方向（买入或卖出）；不与协议兑换费复利
@@ -235,11 +411,19 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 创作者费是在每次兑换时转账的吗？
 
-不是。创作者费在每次兑换时累积到 bucket（`creatorFeeAccrued`），不会立即转账。在活跃曲线期间调用 `claimBondingCurveCreatorFeeV2` 认领，毕业后调用 `claimRaydiumCreatorFeeV2` 认领。
+不是。创作者费在每次兑换时累积到 bucket（`creatorFeeAccrued`），不会立即转账。在活跃曲线期间调用 `claimBondingCurveCreatorFeeV2` 认领。毕业后调用 `collectRaydiumCpmmFeesWithCreatorFeeV2` 从 Raydium 池收集 LP 费用，然后调用 `claimRaydiumCreatorFeeV2` 转移到创作者钱包。
 
-### 任何人都可以调用 `claimBondingCurveCreatorFeeV2` 吗？
+### 任何人都可以调用 `claimBondingCurveCreatorFeeV2` 或 `claimRaydiumCreatorFeeV2` 吗？
 
 是的。三条无需许可的费用指令横跨活跃曲线和毕业后两个阶段——`collectRaydiumCpmmFeesWithCreatorFeeV2` 和 `claimBondingCurveCreatorFeeV2`（活跃曲线）以及 `claimRaydiumCreatorFeeV2`（毕业后）。任何钱包都可以触发，但 SOL 始终发送到配置的创作者费钱包，而非调用方。
+
+### `collectRaydiumCpmmFeesWithCreatorFeeV2` 和 `claimRaydiumCreatorFeeV2` 有什么区别？
+
+`collectRaydiumCpmmFeesWithCreatorFeeV2` 从 Raydium CPMM 池中拉取累积的 LP 交易费用到 Genesis `RaydiumCpmmBucketV2` bucket——这会更新 bucket 上的 `creatorFeeAccrued`。`claimRaydiumCreatorFeeV2` 然后将该 bucket 余额转移到创作者费钱包。必须先运行收集再运行认领；没有收集，就没有 bucket 余额可认领。
+
+### 为什么我的 Raydium bucket 上的 `creatorFeeAccrued` 在池活跃时为零？
+
+`RaydiumCpmmBucketV2` 上的 `creatorFeeAccrued` 仅反映通过 `collectRaydiumCpmmFeesWithCreatorFeeV2` 从 Raydium 收集到 Genesis bucket 的费用。LP 交易费用首先在 Raydium 池状态内累积——直到运行收集指令，它们才会出现在 Genesis bucket 中。
 
 ### 首次购买需要支付创作者费吗？
 
@@ -247,7 +431,7 @@ const result = await claimRaydiumCreatorFeeV2(umi, {
 
 ### 如何检查已累积了多少创作者费？
 
-活跃曲线期间，使用 `fetchBondingCurveBucketV2` 从 `BondingCurveBucketV2` 读取 `creatorFeeAccrued` 字段。毕业后，使用 `fetchRaydiumCpmmBucketV2` 从 `RaydiumCpmmBucketV2` 读取 `creatorFeeAccrued`。详见[检查累积的创作者费](#checking-accrued-creator-fees)。
+活跃曲线期间，使用 `fetchBondingCurveBucketV2` 从 `BondingCurveBucketV2` 读取 `creatorFeeAccrued` 字段。毕业后，使用 `fetchRaydiumCpmmBucketV2` 从 `RaydiumCpmmBucketV2` 读取 `creatorFeeAccrued`。详见[检查累积的创作者费](#检查累积的创作者费)和[检查累积的 Raydium 创作者费](#检查累积的-raydium-创作者费)。
 
 ### 发行后可以更改创作者费钱包吗？
 


### PR DESCRIPTION
Expand the post-graduation creator fees section from a stub into a full two-step flow: collectRaydiumCpmmFeesWithCreatorFeeV2 (harvest LP fees from Raydium pool into Genesis bucket) followed by claimRaydiumCreatorFeeV2 (transfer bucket balance to creator wallet). Includes deriveRaydiumPDAsV2 usage, combined single-tx example, updated FAQ entries, and callout explaining why creatorFeeAccrued may read zero before collecting.