### PR TITLE
Genesis: add CLI tab to Claim Creator Rewards docs across locales

### DIFF
--- a/src/examples/genesis/api_claim_creator_rewards/cli.sh
+++ b/src/examples/genesis/api_claim_creator_rewards/cli.sh
@@ -1,0 +1,9 @@
+# Claim creator rewards across all your bonding-curve and Raydium buckets.
+# Defaults the wallet to the configured signer; network is auto-detected from RPC.
+mplx genesis claim-creator-rewards
+
+# Claim on behalf of a different creator fee wallet (you still pay fees).
+mplx genesis claim-creator-rewards --wallet <CREATOR_FEE_WALLET>
+
+# Force devnet and a specific API base URL.
+mplx genesis claim-creator-rewards --network solana-devnet --apiUrl https://api.metaplex.dev

--- a/src/examples/genesis/api_claim_creator_rewards/index.js
+++ b/src/examples/genesis/api_claim_creator_rewards/index.js
@@ -15,6 +15,14 @@ const umiSections = {
   "full": "// [IMPORTS]\nimport { claimCreatorRewards } from '@metaplex-foundation/genesis'\nimport { base58 } from '@metaplex-foundation/umi/serializers'\nimport { createUmi } from '@metaplex-foundation/umi-bundle-defaults'\nimport { keypairIdentity } from '@metaplex-foundation/umi'\n// [/IMPORTS]\n\n// [SETUP]\nconst umi = createUmi('https://api.mainnet-beta.solana.com')\nconst keypair = umi.eddsa.createKeypairFromSecretKey(mySecretKeyBytes)\numi.use(keypairIdentity(keypair))\n// [/SETUP]\n\n// [MAIN]\nconst result = await claimCreatorRewards(umi, {}, {\n  wallet: umi.identity.publicKey,\n  network: 'solana-mainnet',\n  // payer is optional — defaults to `wallet` on the server.\n  // Set it to have a different wallet cover rent and transaction fees.\n  // payer: umi.identity.publicKey,\n})\n\nfor (const tx of result.transactions) {\n  const signed = await umi.identity.signTransaction(tx)\n  const signature = await umi.rpc.sendTransaction(signed, {\n    preflightCommitment: 'confirmed',\n  })\n  await umi.rpc.confirmTransaction(signature, {\n    strategy: { type: 'blockhash', ...result.blockhash },\n    commitment: 'confirmed',\n  })\n  console.log('Claimed:', base58.deserialize(signature)[0])\n}\n// [/MAIN]\n\n// [OUTPUT]\n// Claimed: 5uGGYEMmjP2HpyFCvLPNpVDSQEBtUE3LR6ZQFqhJxQSh5FbKacSyN8nQmAJowuFs6BTCdwzoFyyJz8Y2hQx8kPxo\n// Claimed: 3TAroVovEap1ZEAJYq3WiDZoMK3GU3soCdrhvZJNg6b9EANqvWrVcDGNffm7mD8wvtpR7ynWQBcbrmz8AK6nrhfy\n// [/OUTPUT]\n"
 }
 
+const cliSections = {
+  "imports": "",
+  "setup": "",
+  "main": "",
+  "output": "",
+  "full": "# Claim creator rewards across all your bonding-curve and Raydium buckets.\n# Defaults the wallet to the configured signer; network is auto-detected from RPC.\nmplx genesis claim-creator-rewards\n\n# Claim on behalf of a different creator fee wallet (you still pay fees).\nmplx genesis claim-creator-rewards --wallet <CREATOR_FEE_WALLET>\n\n# Force devnet and a specific API base URL.\nmplx genesis claim-creator-rewards --network solana-devnet --apiUrl https://api.metaplex.dev\n"
+}
+
 const curlSections = {
   "imports": "",
   "setup": "",
@@ -35,6 +43,13 @@ export const examples = {
     language: 'typescript',
     code: umiSections.full,
     sections: umiSections,
+  },
+
+  cli: {
+    framework: 'CLI',
+    language: 'bash',
+    code: cliSections.full,
+    sections: cliSections,
   },
 
   curl: {

--- a/src/pages/en/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
+++ b/src/pages/en/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
@@ -63,7 +63,7 @@ Set `payer` to a different wallet when the creator fee wallet does not hold SOL 
 
 ## Example Request
 
-{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl" defaultFramework="umi" /%}
+{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl,cli" defaultFramework="umi" /%}
 
 ## Success Response
 

--- a/src/pages/ja/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
+++ b/src/pages/ja/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
@@ -63,7 +63,7 @@ POST /v1/creator-rewards/claim
 
 ## リクエスト例
 
-{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl" defaultFramework="umi" /%}
+{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl,cli" defaultFramework="umi" /%}
 
 ## 成功レスポンス
 

--- a/src/pages/ko/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
+++ b/src/pages/ko/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
@@ -63,7 +63,7 @@ POST /v1/creator-rewards/claim
 
 ## 요청 예시
 
-{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl" defaultFramework="umi" /%}
+{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl,cli" defaultFramework="umi" /%}
 
 ## 성공 응답
 

--- a/src/pages/zh/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
+++ b/src/pages/zh/smart-contracts/genesis/integration-apis/claim-creator-rewards.md
@@ -63,7 +63,7 @@ POST /v1/creator-rewards/claim
 
 ## 请求示例
 
-{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl" defaultFramework="umi" /%}
+{% code-tabs-imported from="genesis/api_claim_creator_rewards" frameworks="umi,curl,cli" defaultFramework="umi" /%}
 
 ## 成功响应
 


### PR DESCRIPTION
Adds a cli.sh example showing the new `mplx genesis claim-creator-rewards` command and registers `cli` in the example-request code-tabs across en/ja/ko/zh so the docs page renders a CLI tab alongside Umi and cURL.

Already merged CLI command: https://github.com/metaplex-foundation/cli/pull/124