### PR TITLE
fix(genesis): set Launch Pool withdraw fee to 0% and correct fee docs

### DIFF
--- a/src/components/products/genesis/index.js
+++ b/src/components/products/genesis/index.js
@@ -47,7 +47,7 @@ export const genesis = {
       },
       withdraw: {
         label: 'User withdraw fee',
-        solana: '2%',
+        solana: '0%',
       },
       creatorWithdraw: {
         label: 'Creator withdraw fee',

--- a/src/pages/en/smart-contracts/genesis/getting-started.md
+++ b/src/pages/en/smart-contracts/genesis/getting-started.md
@@ -172,9 +172,7 @@ Use Unix timestamps (seconds, not milliseconds).
 **What happens:** Users deposit SOL into your inflow bucket(s).
 
 - **Launch Pool:** Users deposit SOL, can withdraw with {% fee product="genesis" config="launchPool" fee="withdraw" /%} fee
-- **Presale:** Users deposit SOL at fixed price, up to a per-user deposit cap (maximum amount each user can contribute)
-
-A {% fee product="genesis" config="launchPool" fee="deposit" /%} protocol fee applies to all deposits.
+- **Presale:** Users deposit SOL at fixed price, up to a per-user deposit cap (maximum amount each user can contribute). See [Presale](/smart-contracts/genesis/presale) for presale fees.
 
 ## Step 5: Transition
 

--- a/src/pages/en/smart-contracts/genesis/launch-pool.md
+++ b/src/pages/en/smart-contracts/genesis/launch-pool.md
@@ -233,7 +233,7 @@ userTokens = (userDeposit / totalDeposits) * tokenAllocation
 
 {% protocol-fees program="genesis" config="launchPool" showTitle=false /%}
 
-Deposit Fee Example: A user deposit of 10 SOL results in 9.8 SOL credited to the user's deposit account.
+Each deposit increases your credited balance by the SOL left after the user deposit fee ({% fee product="genesis" config="launchPool" fee="deposit" /%}) is withheld from the deposit.
 
 ## Setup Guide
 
@@ -426,7 +426,7 @@ if (deposit) {
 
 ## Notes
 
-- The {% fee product="genesis" config="launchPool" fee="deposit" /%} protocol fee applies to both deposits and withdrawals
+- User deposit and withdraw fees for Launch Pool are shown in [Fees](#fees) above.
 - Multiple deposits from the same user accumulate in one deposit account
 - If a user withdraws their entire balance, the deposit PDA closes
 - `triggerBehaviorsV2` must be executed after deposits close for end behaviors to process

--- a/src/pages/ja/smart-contracts/genesis/getting-started.md
+++ b/src/pages/ja/smart-contracts/genesis/getting-started.md
@@ -173,9 +173,7 @@ Unix タイムスタンプ（ミリ秒ではなく秒）を使用してくださ
 **何が起こるか：** ユーザーが Inflow bucket に SOL を入金します。
 
 - **Launch Pool：** ユーザーが SOL を入金し、{% fee product="genesis" config="launchPool" fee="withdraw" /%} の手数料で引き出し可能
-- **Presale：** ユーザーが固定価格で SOL を入金（ユーザーごとの入金上限（各ユーザーが貢献できる最大額）あり）
-
-すべての入金には {% fee product="genesis" config="launchPool" fee="deposit" /%} のプロトコル手数料が適用されます。
+- **Presale：** ユーザーが固定価格で SOL を入金（ユーザーごとの入金上限（各ユーザーが貢献できる最大額）あり）。プレセールの手数料は [Presale](/ja/smart-contracts/genesis/presale) を参照してください。
 
 ## ステップ 5：トランジション
 

--- a/src/pages/ja/smart-contracts/genesis/launch-pool.md
+++ b/src/pages/ja/smart-contracts/genesis/launch-pool.md
@@ -233,7 +233,7 @@ userTokens = (userDeposit / totalDeposits) * tokenAllocation
 
 {% protocol-fees program="genesis" config="launchPool" showTitle=false /%}
 
-入金手数料の例：ユーザーが 10 SOL を入金すると、ユーザーの入金アカウントには 9.8 SOL がクレジットされます。
+各入金では、{% fee product="genesis" config="launchPool" fee="deposit" /%} のユーザー入金手数料を差し引いた後の SOL が入金アカウントの残高に反映されます。
 
 ## セットアップガイド
 
@@ -426,7 +426,7 @@ if (deposit) {
 
 ## 注意事項
 
-- {% fee product="genesis" config="launchPool" fee="deposit" /%} のプロトコル手数料が入金と引き出しの両方に適用されます
+- Launch Pool のユーザー入金・出金手数料は上記の [手数料](#手数料) を参照してください。
 - 同じユーザーからの複数の入金は1つの入金アカウントに蓄積されます
 - ユーザーが残高全額を引き出すと、入金 PDA はクローズされます
 - End Behavior を処理するには、入金終了後に `triggerBehaviorsV2` を実行する必要があります

--- a/src/pages/ko/smart-contracts/genesis/getting-started.md
+++ b/src/pages/ko/smart-contracts/genesis/getting-started.md
@@ -173,9 +173,7 @@ Unix 타임스탬프를 사용합니다 (밀리초가 아닌 초 단위).
 **진행 사항:** 사용자가 Inflow Bucket에 SOL을 예치합니다.
 
 - **Launch Pool:** 사용자가 SOL을 예치하고, {% fee product="genesis" config="launchPool" fee="withdraw" /%} 수수료로 출금 가능
-- **Presale:** 사용자가 고정 가격으로 SOL을 예치하며, 사용자당 예치 상한(각 사용자가 기여할 수 있는 최대 금액)까지 가능
-
-모든 예치에 {% fee product="genesis" config="launchPool" fee="deposit" /%} 프로토콜 수수료가 적용됩니다.
+- **Presale:** 사용자가 고정 가격으로 SOL을 예치하며, 사용자당 예치 상한(각 사용자가 기여할 수 있는 최대 금액)까지 가능합니다. 프리세일 수수료는 [Presale](/ko/smart-contracts/genesis/presale)를 참고하세요.
 
 ## 5단계: Transition
 

--- a/src/pages/ko/smart-contracts/genesis/launch-pool.md
+++ b/src/pages/ko/smart-contracts/genesis/launch-pool.md
@@ -233,7 +233,7 @@ userTokens = (userDeposit / totalDeposits) * tokenAllocation
 
 {% protocol-fees program="genesis" config="launchPool" showTitle=false /%}
 
-예치 수수료 예시: 사용자가 10 SOL을 예치하면 9.8 SOL이 사용자의 예치 계정에 적립됩니다.
+예치 시 {% fee product="genesis" config="launchPool" fee="deposit" /%} 사용자 예치 수수료를 제외한 금액만 예치 계정 잔액에 반영됩니다.
 
 ## 설정 가이드
 
@@ -426,7 +426,7 @@ if (deposit) {
 
 ## 참고 사항
 
-- {% fee product="genesis" config="launchPool" fee="deposit" /%} 프로토콜 수수료가 예치와 출금 모두에 적용됩니다
+- Launch Pool 사용자 예치·출금 수수료는 위 [수수료](#수수료)를 참고하세요.
 - 같은 사용자의 여러 예치금은 하나의 예치 계정에 누적됩니다
 - 사용자가 전체 잔액을 출금하면 예치 PDA가 닫힙니다
 - End behavior를 처리하려면 예치 종료 후 `triggerBehaviorsV2`가 실행되어야 합니다

--- a/src/pages/zh/smart-contracts/genesis/getting-started.md
+++ b/src/pages/zh/smart-contracts/genesis/getting-started.md
@@ -173,9 +173,7 @@ Users deposit SOL → Launch Pool → End Behavior → Unlocked Bucket → Team 
 **发生的事情：** 用户向您的 inflow Bucket 存入 SOL。
 
 - **Launch Pool：** 用户存入 SOL，可以支付 {% fee product="genesis" config="launchPool" fee="withdraw" /%} 费用后提取
-- **Presale：** 用户以固定价格存入 SOL，有每用户存款上限（每个用户可贡献的最大金额）
-
-所有存款都适用 {% fee product="genesis" config="launchPool" fee="deposit" /%} 协议费。
+- **Presale：** 用户以固定价格存入 SOL，有每用户存款上限（每个用户可贡献的最大金额）。预售费用详见 [Presale](/zh/smart-contracts/genesis/presale)。
 
 ## 第 5 步：Transition
 

--- a/src/pages/zh/smart-contracts/genesis/launch-pool.md
+++ b/src/pages/zh/smart-contracts/genesis/launch-pool.md
@@ -233,7 +233,7 @@ userTokens = (userDeposit / totalDeposits) * tokenAllocation
 
 {% protocol-fees program="genesis" config="launchPool" showTitle=false /%}
 
-存款费用示例：用户存入 10 SOL，实际记入用户存款账户的是 9.8 SOL。
+每笔存款：扣除 {% fee product="genesis" config="launchPool" fee="deposit" /%} 用户存款费后的 SOL 净额才会记入存款账户余额。
 
 ## 设置指南
 
@@ -426,7 +426,7 @@ if (deposit) {
 
 ## 注意事项
 
-- {% fee product="genesis" config="launchPool" fee="deposit" /%} 协议费用适用于存款和提款
+- Launch Pool 的用户存款费与提款费见上文 [费用](#费用)。
 - 同一用户的多次存款会累积在一个存款账户中
 - 如果用户提取全部余额，存款 PDA 将被关闭
 - 存款结束后必须执行 `triggerBehaviorsV2` 以处理结束行为


### PR DESCRIPTION
- Update launchPool.withdraw in genesis product config from 2% to 0%
- Fix launch-pool deposit copy to describe net-of-fee crediting with {% fee %}
- Fix Notes and getting-started presale vs Launch Pool fee wording (en/ja/ko/zh)