### PR TITLE
Fix typos and a broken link in English docs

### DIFF
--- a/src/pages/en/dev-tools/umi/getting-started/index.md
+++ b/src/pages/en/dev-tools/umi/getting-started/index.md
@@ -83,7 +83,7 @@ In this section, we'll cover the essential steps to get started with Umi:
 
 Solana has different clusters (e.g., Mainnet-beta, Devnet, Testnet, ...) that serve various purposes, each with dedicated API nodes to handle RPC requests.
 
-Connecting Umi to a cluster of choice is is as simple as creating an umi instance since the RPC endpoint is passed as the first argument.
+Connecting Umi to a cluster of choice is as simple as creating an umi instance since the RPC endpoint is passed as the first argument.
 
 **Note**: If you're connecting to **Mainnet**, it's recommended to use a dedicated RPC endpoint from a Solana RPC provider instead of the public endpoint (`https://api.mainnet-beta.solana.com`) due to its limitations.
 

--- a/src/pages/en/dev-tools/umi/toolbox/token-managment.md
+++ b/src/pages/en/dev-tools/umi/toolbox/token-managment.md
@@ -4,7 +4,7 @@ metaTitle: Token Management | Toolbox
 description: How to manage Token with Umi.
 ---
 
-The following instructions are part of the Token Programm the Associated Token Program and MPL Token Extras Program. The Token Program and Associated Token programs are essential for managing tokens on Solana since they enable you to create Mint accounts, Token accounts, Associated Token PDAs, mint tokens, transfer tokens, delegate tokens, and more. You can learn more about these programs in [Solana's official documentation](https://spl.solana.com/token).
+The following instructions are part of the Token Program, the Associated Token Program and MPL Token Extras Program. The Token Program and Associated Token programs are essential for managing tokens on Solana since they enable you to create Mint accounts, Token accounts, Associated Token PDAs, mint tokens, transfer tokens, delegate tokens, and more. You can learn more about these programs in [Solana's official documentation](https://spl.solana.com/token).
 
 ## Create a Mint
 

--- a/src/pages/en/smart-contracts/bubblegum/guides/javascript/how-to-create-1000000-nfts-on-solana.md
+++ b/src/pages/en/smart-contracts/bubblegum/guides/javascript/how-to-create-1000000-nfts-on-solana.md
@@ -92,7 +92,7 @@ createCnft()
 
 ## Setting up Umi
 
-This example is going to run through setting up Umi with a `generatedSigner()`. If you wish to try this example with React you'll need to setup Umi via the `React - Umi w/ Wallet Adapter` guide. Apart from the wallet setup this guide will use fileStorage keys and wallet adapter.
+This example sets up Umi with `generateSigner(umi)`. If you wish to try this example with React you'll need to setup Umi via the `React - Umi w/ Wallet Adapter` guide. Apart from the wallet setup this guide will use fileStorage keys and wallet adapter.
 
 ### Generating a New Wallet
 

--- a/src/pages/en/smart-contracts/bubblegum/guides/javascript/how-to-create-1000000-nfts-on-solana.md
+++ b/src/pages/en/smart-contracts/bubblegum/guides/javascript/how-to-create-1000000-nfts-on-solana.md
@@ -92,7 +92,7 @@ createCnft()
 
 ## Setting up Umi
 
-This example sets up Umi with `generateSigner(umi)`. If you wish to try this example with React you'll need to setup Umi via the `React - Umi w/ Wallet Adapter` guide. Apart from the wallet setup this guide will use fileStorage keys and wallet adapter.
+This example sets up Umi with `generateSigner(umi)`. If you wish to try this example with React, you'll need to set up Umi via the `React - Umi w/ Wallet Adapter` guide. Apart from the wallet setup, this guide will use fileStorage keys and a wallet adapter.
 
 ### Generating a New Wallet
 

--- a/src/pages/en/smart-contracts/bubblegum/guides/javascript/how-to-create-1000000-nfts-on-solana.md
+++ b/src/pages/en/smart-contracts/bubblegum/guides/javascript/how-to-create-1000000-nfts-on-solana.md
@@ -92,7 +92,7 @@ createCnft()
 
 ## Setting up Umi
 
-This example is going to run through setting up Umi with a `generatedSigner()`. If you wish to try this example with React you'll need to setup Umi via the `React - Umi w/ Wallet Adapter` guide. Apart from the the wallet setup this guide will use fileStorage keys and wallet adapter.
+This example is going to run through setting up Umi with a `generatedSigner()`. If you wish to try this example with React you'll need to setup Umi via the `React - Umi w/ Wallet Adapter` guide. Apart from the wallet setup this guide will use fileStorage keys and wallet adapter.
 
 ### Generating a New Wallet
 
@@ -315,7 +315,7 @@ const nftMetadataUri = await umi.uploader.uploadJson(nftMetadata)
 
 ### Mint cNFT to the Merkle Tree
 
-Minting a cNFT to a tree does not cost any additional account/storage costs on the Solana blockchain as the tree has already been created with enough room for all our cNFT data to be stored (1,000,000 cNFTs in fact). The only additional cost here is just the basic Solana transaction fee making cNFTs incredible efficient to mint in mass.b
+Minting a cNFT to a tree does not cost any additional account/storage costs on the Solana blockchain as the tree has already been created with enough room for all our cNFT data to be stored (1,000,000 cNFTs in fact). The only additional cost here is just the basic Solana transaction fee making cNFTs incredibly efficient to mint en masse.
 
 ```ts
 //

--- a/src/pages/en/smart-contracts/candy-machine/custom-guards/generating-client.md
+++ b/src/pages/en/smart-contracts/candy-machine/custom-guards/generating-client.md
@@ -63,7 +63,7 @@ If you need to run these seperately for what ever reason you are able to do so.
 
 ### Create Guard File
 
-Once a successful generation of the initial client is made navigate to `/clients/js/src`.
+The generated client is located in `/clients/js/src`; navigate there after generation.
 
 The first step would be to add you new guard into the `/clients/js/src/defaultGuards` folder.
 

--- a/src/pages/en/smart-contracts/candy-machine/custom-guards/generating-client.md
+++ b/src/pages/en/smart-contracts/candy-machine/custom-guards/generating-client.md
@@ -63,7 +63,7 @@ If you need to run these seperately for what ever reason you are able to do so.
 
 ### Create Guard File
 
-Once a sucessful generation of the intial client is made navigate to `/clients/js/src`.
+Once a successful generation of the initial client is made navigate to `/clients/js/src`.
 
 The first step would be to add you new guard into the `/clients/js/src/defaultGuards` folder.
 

--- a/src/pages/en/smart-contracts/candy-machine/insert-items.md
+++ b/src/pages/en/smart-contracts/candy-machine/insert-items.md
@@ -81,7 +81,7 @@ await addConfigLines(umi, {
 }).sendAndConfirm(umi)
 ```
 
-To simply append items to the end of the currently loaded items, you may using the `candyMachine.itemsLoaded` property as the index like so.
+To simply append items to the end of the currently loaded items, you may use the `candyMachine.itemsLoaded` property as the index like so.
 
 ```ts
 await addConfigLines(umi, {

--- a/src/pages/en/smart-contracts/core-candy-machine/create.md
+++ b/src/pages/en/smart-contracts/core-candy-machine/create.md
@@ -285,7 +285,7 @@ By storing the Assets name and URI prefix into the Core Candy Machine the data r
 
 For example if all your Assets had the same naming structure of `Example Asset #1` through to `Example Asset #1000` this would normally require you to store the string `Example Asset #` 1000 times, taking up 15,000 bytes.
 
-By storing the prefix of the name in the Core Candy Machine and letting the Core Candy Machine append the index number created to the string you save these 15,000 bytes in rent cost.
+By storing the name prefix once on the Core Candy Machine and appending the asset index at mint time, you avoid repeating that prefix for every Asset and reduce account storage (and the associated rent).
 
 This also applies to the URI prefix.
 

--- a/src/pages/en/smart-contracts/core-candy-machine/create.md
+++ b/src/pages/en/smart-contracts/core-candy-machine/create.md
@@ -285,7 +285,7 @@ By storing the Assets name and URI prefix into the Core Candy Machine the data r
 
 For example if all your Assets had the same naming structure of `Example Asset #1` through to `Example Asset #1000` this would normally require you to store the string `Example Asset #` 1000 times, taking up 15,000 bytes.
 
-By storing the prefix of the name in the the Core Candy Machine and letting the Core Candy Machine append the index number created to the string you save these 15,000 bytes in rent cost.
+By storing the prefix of the name in the Core Candy Machine and letting the Core Candy Machine append the index number created to the string you save these 15,000 bytes in rent cost.
 
 This also applies to the URI prefix.
 

--- a/src/pages/en/smart-contracts/core-candy-machine/insert-items.md
+++ b/src/pages/en/smart-contracts/core-candy-machine/insert-items.md
@@ -79,7 +79,7 @@ await addConfigLines(umi, {
 }).sendAndConfirm(umi)
 ```
 
-To simply append items to the end of the currently loaded items, you may using the `candyMachine.itemsLoaded` property as the index like so.
+To simply append items to the end of the currently loaded items, you may use the `candyMachine.itemsLoaded` property as the index like so.
 
 ```ts
 await addConfigLines(umi, {

--- a/src/pages/en/smart-contracts/core/external-plugins/overview.md
+++ b/src/pages/en/smart-contracts/core/external-plugins/overview.md
@@ -50,7 +50,7 @@ Built-in plugins (see [Plugins Overview](/smart-contracts/core/plugins)), creati
 2. Create/deploy the external account (Oracle) or configure data authority (AppData)
 3. Add the plugin adapter to your Asset or Collection
 ## What are External Plugins?
-External Plugins are [Authority Managed](/smart-contracts/core/plugins#authority-managed-plugins), consisting of 2 parts, the **Adapter**, and the **Plugin**. A **Plugin Adapter** is assigned to the Assets/Collection and allows data and validations to to be passed from an External Plugin. The External Plugin provides data and validations for the **Plugin Adapter**.
+External Plugins are [Authority Managed](/smart-contracts/core/plugins#authority-managed-plugins), consisting of 2 parts, the **Adapter**, and the **Plugin**. A **Plugin Adapter** is assigned to the Assets/Collection and allows data and validations to be passed from an External Plugin. The External Plugin provides data and validations for the **Plugin Adapter**.
 ## Lifecycle Checks
 Each External Plugin comes with the ability to assign lifecycle checks to Lifecycle Events influencing the behavior of the lifecycle event that is trying to take place. The lifecycle checks available are:
 - Create

--- a/src/pages/en/smart-contracts/core/transfer.md
+++ b/src/pages/en/smart-contracts/core/transfer.md
@@ -94,11 +94,15 @@ If you are transferring an Asset which has a collection you will need to pass th
 ```ts
 import { publicKey } from '@metaplex-foundation/umi'
 import { transferV1 } from '@metaplex-foundation/mpl-core'
+
 const asset = publicKey('11111111111111111111111111111111')
+const collection = publicKey('22222222222222222222222222222222')
+const newOwner = publicKey('33333333333333333333333333333333')
+
 await transferV1(umi, {
-  asset: asset.publicKey,
-  newOwner: newOwner.publicKey,
-  collection: collection.publicKey,
+  asset,
+  newOwner,
+  collection,
 }).sendAndConfirm(umi)
 ```
 {% /dialect %}

--- a/src/pages/en/smart-contracts/core/transfer.md
+++ b/src/pages/en/smart-contracts/core/transfer.md
@@ -88,7 +88,7 @@ A full detailed look at the on chain instruction it can be viewed on [Github](ht
 {% code-tabs-imported from="core/transfer-asset" frameworks="umi" /%}
 ## Transferring a Core Asset in a Collection
 If you are transferring an Asset which has a collection you will need to pass the collection address in.
-[How to tell if an asset is in a Collection?]()
+[How to tell if an asset is in a Collection?](#how-do-i-know-if-an-asset-is-in-a-collection)
 {% dialect-switcher title="Transfer an Asset that is part of a Collection" %}
 {% dialect title="JavaScript" id="js" %}
 ```ts
@@ -98,7 +98,7 @@ const asset = publicKey('11111111111111111111111111111111')
 await transferV1(umi, {
   asset: asset.publicKey,
   newOwner: newOwner.publicKey,
-  collection: colleciton.publicKey,
+  collection: collection.publicKey,
 }).sendAndConfirm(umi)
 ```
 {% /dialect %}

--- a/src/pages/en/smart-contracts/core/transfer.md
+++ b/src/pages/en/smart-contracts/core/transfer.md
@@ -96,8 +96,8 @@ import { publicKey } from '@metaplex-foundation/umi'
 import { transferV1 } from '@metaplex-foundation/mpl-core'
 
 const asset = publicKey('11111111111111111111111111111111')
-const collection = publicKey('22222222222222222222222222222222')
-const newOwner = publicKey('33333333333333333333333333333333')
+const collection = publicKey('22222222222222222222222222222222222222222222')
+const newOwner = publicKey('33333333333333333333333333333333333333333333')
 
 await transferV1(umi, {
   asset,
@@ -116,8 +116,8 @@ pub async fn transfer_asset_in_collection() {
     let rpc_client = rpc_client::RpcClient::new("https://api.devnet.solana.com".to_string());
     let authority = Keypair::new();
     let asset = Pubkey::from_str("11111111111111111111111111111111").unwrap();
-    let collection = Pubkey::from_str("22222222222222222222222222222222").unwrap();
-    let new_owner = Pubkey::from_str("33333333333333333333333333333333").unwrap();
+    let collection = Pubkey::from_str("22222222222222222222222222222222222222222222").unwrap();
+    let new_owner = Pubkey::from_str("33333333333333333333333333333333333333333333").unwrap();
     let transfer_asset_in_collection_ix = TransferV1Builder::new()
         .asset(asset)
         .collection(Some(collection))


### PR DESCRIPTION
Correct grammar and spelling issues across Core, Candy Machine, Bubblegum, and Umi pages, and point the empty collection FAQ link to the in-page section.