### PR TITLE
docs(solana): interactive PLGRND flows for PDAs, priority fees and transaction anatomy

### DIFF
--- a/src/components/products/guides/index.js
+++ b/src/components/products/guides/index.js
@@ -39,7 +39,7 @@ export const guides = {
               title: 'Solana Transaction Fundamentals',
               href: '/solana/solana-transaction-fundamentals',
               created: '02-04-2026',
-              updated: null,
+              updated: '09-03-2026',
             },
             {
               title: 'Solana Programs',
@@ -51,7 +51,7 @@ export const guides = {
               title: 'Understanding PDAs',
               href: '/solana/understanding-pdas',
               created: '2021-10-01',
-              updated: null,
+              updated: '09-03-2026',
             },
             {
               title: 'Validators and Staking',
@@ -81,7 +81,7 @@ export const guides = {
               title: 'Compute Units and Priority Fees',
               href: '/solana/compute-units-and-priority-fees',
               created: '02-04-2026',
-              updated: null,
+              updated: '09-03-2026',
             },
           ],
         },

--- a/src/pages/en/solana/compute-units-and-priority-fees.md
+++ b/src/pages/en/solana/compute-units-and-priority-fees.md
@@ -4,7 +4,7 @@ metaTitle: Compute Units and Priority Fees | Solana Transaction Optimization
 description: Learn how to optimize Solana transactions with compute units and priority fees for better landing rates during network congestion.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 Master compute units and priority fees to ensure your transactions land reliably, even during network congestion. {% .lead %}
@@ -87,6 +87,10 @@ Priority Fee: 200,000 × 1,000 = 200,000,000 micro-lamports
             = 200,000 lamports
             = 0.0002 SOL
 ```
+
+Try it: change the compute unit limit or the price and the fee updates live.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJmiyAvvBQBDSjskhKaKZSIAFAE5jrNAAQAzNGjsBeO8SQBbWgFdjdr4IIhh2AOt2tNbELgAUXnjElkhKADY6PkiWlKH0lnaMAKoAlHYA73aksLI11TUAOgg8SPqpjs5ukdZZItTtLgDUdgBGOhguTnEArHWydumZ2blo+cIA5gh6vpZoxY2NpPMZgtmdVTXyF3YJSSkLJzkAdAUAFjoIay6ULy5chawAIQ4ACU7HgEH4cnZxHZvi5UmgHJRHiANFp8IRICQVPwaPQmGxOLx+IJhKJxIYZJAlNAVPIQIpqaRNNo9AZIKBjKYiIAEwg83khLiCInmeASZjRsAxRAQ5CodAYWL+gJBJKEIjEEg5ICp9MZLJAun0hgQvi8wxWUDpF006JABCIxGguIVBPY3D48FJGop2qpNLpCigAA4DUb2ZyTGYsXyook0LBrolkmljlkoXkCoVUXaHViEDj5filf8gcC1WTNZS5EHIABOMNsk1mi2WKDMi6S6VY4gAFhdxZALHdxK96vJWukylpevbDa0hqb2q50ZAfJuKfu6eW+S32RzUvtmMQzqLipAyrLFZ9k51NYZVpqC-DzfNlsgHZtXaPjoAbAPz2HIlPQEccqz9adAwfGAn1ZY1lyjXkRjGCYOkzdZNkobYEyORYcgPbtEH7M8iEvVUx0rX0p0gWcYGZZ8l1AU03zbSApk7XNjy8OUjFdLFWEKAAZHgAElzEEgBNa8J2rSBrVrXspgY+DgG-PNDTAHi8XPAARESADURJ0jhpPA6joFDWtSHouCIzU49Ui0viQEEgBBVhzGYYEeAAZQAfR4Zg-J85hBNMqi7zY39aOi5S7M4x0pgAt1gPC28qQAdks6D2LiwwVyQuMensSZExCsL7KIHQnMHVydJ0tLZKmaLaxUOk8o5SqsVSQteMHNyPK83yAqC8rGogyAMt7Wi2sbFSupIDLkqxICPXG6i6xa6CVBsxcVKMRCY1hFodDaUq7HKuxYkODCth2YocwAXXgNAUE+LBIFwH8sSkaglFez4-L82UlGY1slGsNYXkoJRuKUHQ0kRMx4AwJBthiGUeNR9G0AACXeFAEUx0GWxWCG8Ch5GjB0SxPlXbjcRpun8YQQnzzhhGESRVFD3U37-retAgYLEmWPJynYdIJRhkR7mUbRywMfzXrscVvGCaJ5XRfByHocZ2m0HprSmcNlm2aIOGZa5iVeePfmAaFvy4Z2DBfFSGHdZhlBNPh2WqdVpWQAZ+WcbNzWg6ll23Y9im9aoE3V2942DcoMPzyT33rZ5wj7cF4XoG1snPaUDOraR-gA-PBBTxASu05lAuwaL2Oqf0FOiCT-XmY19OfbL7mEp+v6HaBjOo-d8XobSKW9xyP2K4VwPO5DtX66xMfMGjyfW4TohHK702e73me0yWefB51Ye878jfXYn4vqsz8uV6XzSF9Do-1598eY8pg-V2qv-NeIBH6c3LhfXOgNga9kLpYbe8Mpb939ovKuxFa4oOAQgGBTc4Ge3-lVZO3dWbh0fkg7O31L4CygY-H+8CeqpjwhgeeL9zyAJYcAmhm974t3wd1XqbciHmz4Qwh4TCs4aEehoIAA" embed=true /%}
 
 ### When to Use Priority Fees
 

--- a/src/pages/en/solana/solana-transaction-fundamentals.md
+++ b/src/pages/en/solana/solana-transaction-fundamentals.md
@@ -4,7 +4,7 @@ metaTitle: Solana Transaction Fundamentals | How Transactions Work
 description: Learn how Solana transactions work, including structure, signing, sending, and confirmation. Essential knowledge for building reliable applications.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 A comprehensive guide to understanding how Solana transactions work from structure to confirmation. {% .lead %}
@@ -57,6 +57,12 @@ A Solana transaction consists of several components:
 | **Recent Blockhash** | A recent block hash (valid for ~60-90 seconds) |
 | **Instructions** | The operations to perform |
 | **Account Keys** | All accounts involved in the transaction |
+
+### See a real transaction
+
+The flow below fetches a mainnet transaction with `getTransaction` and shows the raw structure from the diagram above: `signatures`, `message.header`, `accountKeys`, `recentBlockhash` and `instructions` (the example is a 2022 Token Metadata call). Paste any signature into the first node and press **Refresh** to inspect your own transaction.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0pAKyyAvvBQBDSjskhKaKZSIAFHRmMACHQmo2AtjrwIEaSjcoAnexh1iUXEbYQBzBD0AVx80GzdKJG8ACzieDgANHhtkdAA6Gx4AJQBBLgBlEsYeAElmLhsANRqOAHUbADNPYlSMeK8wPB0bMM8ePwQAoLEEAG4UuIApcvqbEMpUmx88MOSvPD6NuNidABs7SMSnakhQncuYzFhnTADRvNSddB9nwOIkKIISgAaTQ1Awz1ixDQQIAQqckMQANbJKzJZ5uaw+KLTcQYPIgDRafCESBGchUOgMMnpLL8QTCYISSDSOQKORaEC6fSGYymIgALwAVrCAI4ALR8HVU5QAbChxcCihhykVWgAOABGABkpABODo8NAAMQ6wJQRWgyUY0AA7gBFPAlWElShOe3lcq2jpSKQ+EoAJmoRWSkT1yBK9u1SAAqkKnOYAwAWTXmRbGgAirVIrXFCEa1EaYT15UJxJABCIHjMlPoRC4HB4rWYRWB9KEIhmhhkkHkIEUkD1mm0egMLMQnltSB8SKIrBKNS4Db4RNgJKIYApRipRGKZUq1TqXAA+s02u3GV3xz2k7I+wPb5zuWPgKv12SUFuaHWyRmauVzG1EoAE0L07cRuygAB2dV72UWVhy5UdeRMMwyTLNcK1JLkA34b9qRAP8AKA0D4AZcDmVZSAYLgyAAwQp9kPHPk0JADD3y5aA8J3X9-0AkCwKZSDqNg9kYEfEceWY1CiHYrCiGIXDawIlh2G4PgyI7ITrygUhSDvMSA3URipNAFiiEABMJQgRLx7BQGxNQRZFvDwJwGCJABdeA0BQUYsEgXB5LJKRqCUHzRmPY9KFIJQWKUbZdkoJRNyUcIHliJRTjQDoaxADAAR8aEiGi-h8piaEAAk7Ky4qYrihK9jwnQfFGVjNyalrPCqhAUBqskUrS6IMqynLCUwytgtC8K0Ei6slGrKcZ3inY9mSmKFunJFMuy3KysKgjq1KgrKuqg7PHmydNuWxKOtajcv2a1rut6giUo2paRrMcsJpAEKwt8mbjxS3x-ECJlFnyhBrtWz8lDcWgoiSz6jvK16tz2k6er68A6omKZwch6Hcv0TrWM-W6utOohYfhxHttG77sL+6bIoGmyiaUFAAzhhAEaRnaUf2+7Bcxl77tS9mGuJx7PGppSjBlyhnuxrmeb5+mvvGpmpoB1mYscxEkR4Vy0A5lBoDVunkfgDG0ZFtBlbRpQDeRY23KJimya4qhFcd6mLdp-mGY8jQgA" embed=true /%}
 
 ## Instructions
 

--- a/src/pages/en/solana/understanding-pdas.md
+++ b/src/pages/en/solana/understanding-pdas.md
@@ -4,7 +4,7 @@ metaTitle: Understanding Solana Program Derived Addresses | Guides
 description: Learn about Solana Program Derived Addresses (PDAs) and their use cases.
 # remember to update dates also in /components/products/guides/index.js
 created: '04-19-2024'
-updated: '04-19-2025'
+updated: '09-03-2026'
 keywords:
   - Program Derived Addresses
   - PDA
@@ -48,6 +48,18 @@ PDAs are derived using a combination of a program ID and a set of seed values. T
 1. **Select Program ID**: The public key of the program for which the PDA is being derived.
 2. **Choose Seeds**: One or more seed values that, together with the program ID, will deterministically generate the PDA algorithmically based on the combined values.
 3. **Compute PDA**: Use the `Pubkey::find_program_address` function to derive the PDA. This function ensures the derived address is valid and cannot collide with any regular (non-PDA) address.
+
+### Try it live: the Token Metadata PDA
+
+Every token's metadata account is a PDA of the Token Metadata program, derived from three seeds: the string `"metadata"`, the program id `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s` and the mint. The flow below runs `find_program_address` in your browser. Replace the mint (third input) with any mint and the metadata address updates — this is exactly what `findMetadataPda(umi, { mint })` returns.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJgAssgL7wUAQ0q7JISmimUirNAdoAbUwAIeSANZoE9ywb0H7ABQAiAIIAOgihGGhoKBj2ALz22MEgALZWut66SbD2lC5u9qle+rr2tABOSADmZbrJ9gTZyXgIlAC6oeVVNXXxua7uhenFpRXVtaGhHCgiOQAWaAXNlPYAFJSzeGUojhwAGjz2yOgAlPa6CNsA7vrEs3MLgxlnxMRIAK4tZygoZZgxb7RvGgAHSODYxPAxUy6YiUGzUeyXWb6ewAM2aKE8QwMvj0KzeTWywEWn00p1eyVobxMGGBIE02nwhEgxnIVDoDBZPD2fHggmEonERhkkHkIEUou0IAyRhMZiIj2K9MZIAIREoKn4NHoRG5+34-JEYgkkGkcgUUAAnFodErTcZTOYWYMAI4AIykUgAqmgti6VAAOYgAK1IACU3YEAOrOACaAEVktBqG6AF7Bt0ANl0AbdlAArKQA1JSFgGbAmeroFqObqeQahEahfaRWKJUWbdK7aA5U6QBxfMGAGJR775wJvVEugDK05daFYKhdXFIUlTKd0tEYAYA4mpLhwdzvnAAtS7UHj+SikCDlyss2hs4y1lkBQINgXG4VQNQqNtWzsZVNO9VWZaUn21TkQH8ABJadfAAGUCWMPybE0zUgTNM3-SANClICe0dIh8ykaAAwAaVoNRZjAFAkGSHhGAQRgykCBBqDUL1KFYLj8zKeMACEUAEzNaCkFRyNIL08DUfMoxdZUK1AogUE1dkdRZWD4KQlC+UbQV0JAEUsJw0h80A7sHXlFkVHzfNFPvEg1OfDSQBYdhuF5AR9K-FsoBMi1ICUUhSAsgxZSIlksSeGFXg+ZZ0h+P5VlRJAynuewvWnfxGBJShTnObZ1gWYhznEPBSpsew3QJWg6QZVp4CiSpMBwRypGoJRmrQAB9HqNSUXslDKPBKlmSglEfSbRm6GCUCUOxUXMeAMHeMpiCgjV+FWt51rQAAJQq7HVFRBsdYbRvGrVdDKFq+0fa7bqsQ6LmOh9SGmrpajmha0CW+klLVFkOq6lAWr668zrMC6xomqaIiiABiWRfv+la1o29Unx2vaXpQN7WShiaRthx67qIB6qBuu68YJ+HIhQZHUfMFUgaMzruoh06hpJ8bJo+hHGY+xblpAHHMZZLb0d2jbac27nzt50WDCe+6IOp56jqg+mkeFv6WcBsCQc5-roCJmG+Z1xnTpF7aMc26tpdxrWq3NpWyasCn1dVuWvaUQXEZt-WAfajmwd6nqpsBXQLYmlAPuaKkJttp2JYEbH7d997Jr0WOPb7eP86z8ClET6lmZD5TgbD8HI4+mrKVjpRVNLhAk4r1PtYzmWDpd7OG9oPOqdVlTnJVmm++lU6y+T4PNFaTQgA" embed=true /%}
+
+```javascript
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata'
+
+const [metadataPda, bump] = findMetadataPda(umi, { mint })
+```
 
 ## Example in Rust
 Here's an example of deriving a PDA in a Solana program written in Rust:

--- a/src/pages/ja/solana/compute-units-and-priority-fees.md
+++ b/src/pages/ja/solana/compute-units-and-priority-fees.md
@@ -4,7 +4,7 @@ metaTitle: Compute Units and Priority Fees | Solana Transaction Optimization
 description: Learn how to optimize Solana transactions with compute units and priority fees for better landing rates during network congestion.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 Master compute units and priority fees to ensure your transactions land reliably, even during network congestion. {% .lead %}
@@ -82,11 +82,16 @@ Priority Fee = Compute Units × Compute Unit Price (in micro-lamports)
 
 ```
 Compute Units: 200,000
-Price: 1,000 micro-lamports per CU
-Priority Fee: 200,000 × 1,000 = 200,000,000 micro-lamports
-            = 200,000 lamports
-            = 0.0002 SOL
+Price: 10,000 micro-lamports per CU
+Priority Fee: 200,000 × 10,000 = 2,000,000,000 micro-lamports
+            = 2,000 lamports          (1 lamport = 1,000,000 micro-lamports)
+            = 0.000002 SOL
+Total fee:    2,000 + 5,000 (base fee, 1 signature) = 7,000 lamports = 0.000007 SOL
 ```
+
+Try it: change the compute unit limit or the price and the fee updates live.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJmiyAvvBQBDSjskhKaKZSIAFAE5jrNAAQAzNGjsBeO8SQBbWgFdjdr4IIhh2AOt2tNbELgAUXnjElkhKADY6PkiWlKH0lnaMAKoAlHYA73aksLI11TUAOgg8SPqpjs5ukdZZItTtLgDUdgBGOhguTnEArHWydumZ2blo+cIA5gh6vpZoxY2NpPMZgtmdVTXyF3YJSSkLJzkAdAUAFjoIay6ULy5chawAIQ4ACU7HgEH4cnZxHZvi5UmgHJRHiANFp8IRICQVPwaPQmGxOLx+IJhKJxIYZJAlNAVPIQIpqaRNNo9AZIKBjKYiIAEwg83khLiCInmeASZjRsAxRAQ5CodAYWL+gJBJKEIjEEg5ICp9MZLJAun0hgQvi8wxWUDpF006JABCIxGguIVBPY3D48FJGop2qpNLpCigAA4DUb2ZyTGYsXyook0LBrolkmljlkoXkCoVUXaHViEDj5filf8gcC1WTNZS5EHIABOMNsk1mi2WKDMi6S6VY4gAFhdxZALHdxK96vJWukylpevbDa0hqb2q50ZAfJuKfu6eW+S32RzUvtmMQzqLipAyrLFZ9k51NYZVpqC-DzfNlsgHZtXaPjoAbAPz2HIlPQEccqz9adAwfGAn1ZY1lyjXkRjGCYOkzdZNkobYEyORYcgPbtEH7M8iEvVUx0rX0p0gWcYGZZ8l1AU03zbSApk7XNjy8OUjFdLFWEKAAZHgAElzEEgBNa8J2rSBrVrXspgY+DgG-PNDTAHi8XPAARESADURJ0jhpPA6joFDWtSHouCIzU49Ui0viQEEgBBVhzGYYEeAAZQAfR4Zg-J85hBNMqi7zY39aOi5S7M4x0pgAt1gPC28qQAdks6D2LiwwVyQuMensSZExCsL7KIHQnMHVydJ0tLZKmaLaxUOk8o5SqsVSQteMHNyPK83yAqC8rGogyAMt7Wi2sbFSupIDLkqxICPXG6i6xa6CVBsxcVKMRCY1hFodDaUq7HKuxYkODCth2YocwAXXgNAUE+LBIFwH8sSkaglFez4-L82UlGY1slGsNYXkoJRuKUHQ0kRMx4AwJBthiGUeNR9G0AACXeFAEUx0GWxWCG8Ch5GjB0SxPlXbjcRpun8YQQnzzhhGESRVFD3U37-retAgYLEmWPJynYdIJRhkR7mUbRywMfzXrscVvGCaJ5XRfByHocZ2m0HprSmcNlm2aIOGZa5iVeePfmAaFvy4Z2DBfFSGHdZhlBNPh2WqdVpWQAZ+WcbNzWg6ll23Y9im9aoE3V2942DcoMPzyT33rZ5wj7cF4XoG1snPaUDOraR-gA-PBBTxASu05lAuwaL2Oqf0FOiCT-XmY19OfbL7mEp+v6HaBjOo-d8XobSKW9xyP2K4VwPO5DtX66xMfMGjyfW4TohHK702e73me0yWefB51Ye878jfXYn4vqsz8uV6XzSF9Do-1598eY8pg-V2qv-NeIBH6c3LhfXOgNga9kLpYbe8Mpb939ovKuxFa4oOAQgGBTc4Ge3-lVZO3dWbh0fkg7O31L4CygY-H+8CeqpjwhgeeL9zyAJYcAmhm974t3wd1XqbciHmz4Qwh4TCs4aEehoIAA" embed=true /%}
 
 ### When to Use Priority Fees
 

--- a/src/pages/ja/solana/solana-transaction-fundamentals.md
+++ b/src/pages/ja/solana/solana-transaction-fundamentals.md
@@ -4,7 +4,7 @@ metaTitle: Solana Transaction Fundamentals | How Transactions Work
 description: Learn how Solana transactions work, including structure, signing, sending, and confirmation. Essential knowledge for building reliable applications.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 A comprehensive guide to understanding how Solana transactions work from structure to confirmation. {% .lead %}
@@ -57,6 +57,12 @@ A Solana transaction consists of several components:
 | **Recent Blockhash** | A recent block hash (valid for ~60-90 seconds) |
 | **Instructions** | The operations to perform |
 | **Account Keys** | All accounts involved in the transaction |
+
+### See a real transaction
+
+The flow below fetches a mainnet transaction with `getTransaction` and shows the raw structure from the diagram above: `signatures`, `message.header`, `accountKeys`, `recentBlockhash` and `instructions` (the example is a 2022 Token Metadata call). Paste any signature into the first node and press **Refresh** to inspect your own transaction.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0pAKyyAvvBQBDSjskhKaKZSIAFHRmMACHQmo2AtjrwIEaSjcoAnexh1iUXEbYQBzBD0AVx80GzdKJG8ACzieDgANHhtkdAA6Gx4AJQBBLgBlEsYeAElmLhsANRqOAHUbADNPYlSMeK8wPB0bMM8ePwQAoLEEAG4UuIApcvqbEMpUmx88MOSvPD6NuNidABs7SMSnakhQncuYzFhnTADRvNSddB9nwOIkKIISgAaTQ1Awz1ixDQQIAQqckMQANbJKzJZ5uaw+KLTcQYPIgDRafCESBGchUOgMMnpLL8QTCYISSDSOQKORaEC6fSGYymIgALwAVrCAI4ALR8HVU5QAbChxcCihhykVWgAOABGABkpABODo8NAAMQ6wJQRWgyUY0AA7gBFPAlWElShOe3lcq2jpSKQ+EoAJmoRWSkT1yBK9u1SAAqkKnOYAwAWTXmRbGgAirVIrXFCEa1EaYT15UJxJABCIHjMlPoRC4HB4rWYRWB9KEIhmhhkkHkIEUkD1mm0egMLMQnltSB8SKIrBKNS4Db4RNgJKIYApRipRGKZUq1TqXAA+s02u3GV3xz2k7I+wPb5zuWPgKv12SUFuaHWyRmauVzG1EoAE0L07cRuygAB2dV72UWVhy5UdeRMMwyTLNcK1JLkA34b9qRAP8AKA0D4AZcDmVZSAYLgyAAwQp9kPHPk0JADD3y5aA8J3X9-0AkCwKZSDqNg9kYEfEceWY1CiHYrCiGIXDawIlh2G4PgyI7ITrygUhSDvMSA3URipNAFiiEABMJQgRLx7BQGxNQRZFvDwJwGCJABdeA0BQUYsEgXB5LJKRqCUHzRmPY9KFIJQWKUbZdkoJRNyUcIHliJRTjQDoaxADAAR8aEiGi-h8piaEAAk7Ky4qYrihK9jwnQfFGVjNyalrPCqhAUBqskUrS6IMqynLCUwytgtC8K0Ei6slGrKcZ3inY9mSmKFunJFMuy3KysKgjq1KgrKuqg7PHmydNuWxKOtajcv2a1rut6giUo2paRrMcsJpAEKwt8mbjxS3x-ECJlFnyhBrtWz8lDcWgoiSz6jvK16tz2k6er68A6omKZwch6Hcv0TrWM-W6utOohYfhxHttG77sL+6bIoGmyiaUFAAzhhAEaRnaUf2+7Bcxl77tS9mGuJx7PGppSjBlyhnuxrmeb5+mvvGpmpoB1mYscxEkR4Vy0A5lBoDVunkfgDG0ZFtBlbRpQDeRY23KJimya4qhFcd6mLdp-mGY8jQgA" embed=true /%}
 
 ## Instructions
 

--- a/src/pages/ja/solana/understanding-pdas.md
+++ b/src/pages/ja/solana/understanding-pdas.md
@@ -4,7 +4,7 @@ title: Solana Program Derived Addresses (PDAs) の理解
 metaTitle: Solana Program Derived Addresses の理解 | ガイド
 description: Solana Program Derived Addresses（PDAs）とその使用事例について学びます。
 created: '04-19-2024'
-updated: '04-19-2025'
+updated: '09-03-2026'
 keywords:
   - Program Derived Addresses
   - PDA
@@ -48,6 +48,18 @@ PDAは、プログラムIDとシード値のセットの組み合わせを使用
 1. **プログラムIDの選択**: PDAが導出されるプログラムのパブリックキー。
 2. **シードの選択**: プログラムIDと組み合わせて、結合された値に基づいて決定論的にPDAをアルゴリズム的に生成する1つ以上のシード値。
 3. **PDAの計算**: `Pubkey::find_program_address`関数を使用してPDAを導出します。この関数は、導出されたアドレスが有効であり、通常の（非PDA）アドレスと衝突しないことを保証します。
+
+### 実際に試す: Token Metadata の PDA
+
+すべてのトークンのメタデータアカウントは Token Metadata プログラムの PDA で、3 つのシード（文字列 `"metadata"`、プログラム ID `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`、mint）から導出されます。下のフローはブラウザ内で `find_program_address` を実行します。3 番目の入力の mint を任意の mint に置き換えると、メタデータアドレスが更新されます。これは `findMetadataPda(umi, { mint })` が返す値そのものです。
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJgAssgL7wUAQ0q7JISmimUirNAdoAbUwAIeSANZoE9ywb0H7ABQAiAIIAOgihGGhoKBj2ALz22MEgALZWut66SbD2lC5u9qle+rr2tABOSADmZbrJ9gTZyXgIlAC6oeVVNXXxua7uhenFpRXVtaGhHCgiOQAWaAXNlPYAFJSzeGUojhwAGjz2yOgAlPa6CNsA7vrEs3MLgxlnxMRIAK4tZygoZZgxb7RvGgAHSODYxPAxUy6YiUGzUeyXWb6ewAM2aKE8QwMvj0KzeTWywEWn00p1eyVobxMGGBIE02nwhEgxnIVDoDBZPD2fHggmEonERhkkHkIEUou0IAyRhMZiIj2K9MZIAIREoKn4NHoRG5+34-JEYgkkGkcgUUAAnFodErTcZTOYWYMAI4AIykUgAqmgti6VAAOYgAK1IACU3YEAOrOACaAEVktBqG6AF7Bt0ANl0AbdlAArKQA1JSFgGbAmeroFqObqeQahEahfaRWKJUWbdK7aA5U6QBxfMGAGJR775wJvVEugDK05daFYKhdXFIUlTKd0tEYAYA4mpLhwdzvnAAtS7UHj+SikCDlyss2hs4y1lkBQINgXG4VQNQqNtWzsZVNO9VWZaUn21TkQH8ABJadfAAGUCWMPybE0zUgTNM3-SANClICe0dIh8ykaAAwAaVoNRZjAFAkGSHhGAQRgykCBBqDUL1KFYLj8zKeMACEUAEzNaCkFRyNIL08DUfMoxdZUK1AogUE1dkdRZWD4KQlC+UbQV0JAEUsJw0h80A7sHXlFkVHzfNFPvEg1OfDSQBYdhuF5AR9K-FsoBMi1ICUUhSAsgxZSIlksSeGFXg+ZZ0h+P5VlRJAynuewvWnfxGBJShTnObZ1gWYhznEPBSpsew3QJWg6QZVp4CiSpMBwRypGoJRmrQAB9HqNSUXslDKPBKlmSglEfSbRm6GCUCUOxUXMeAMHeMpiCgjV+FWt51rQAAJQq7HVFRBsdYbRvGrVdDKFq+0fa7bqsQ6LmOh9SGmrpajmha0CW+klLVFkOq6lAWr668zrMC6xomqaIiiABiWRfv+la1o29Unx2vaXpQN7WShiaRthx67qIB6qBuu68YJ+HIhQZHUfMFUgaMzruoh06hpJ8bJo+hHGY+xblpAHHMZZLb0d2jbac27nzt50WDCe+6IOp56jqg+mkeFv6WcBsCQc5-roCJmG+Z1xnTpF7aMc26tpdxrWq3NpWyasCn1dVuWvaUQXEZt-WAfajmwd6nqpsBXQLYmlAPuaKkJttp2JYEbH7d997Jr0WOPb7eP86z8ClET6lmZD5TgbD8HI4+mrKVjpRVNLhAk4r1PtYzmWDpd7OG9oPOqdVlTnJVmm++lU6y+T4PNFaTQgA" embed=true /%}
+
+```javascript
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata'
+
+const [metadataPda, bump] = findMetadataPda(umi, { mint })
+```
 
 ## Rustでの例
 以下は、Rustで書かれたSolanaプログラムでPDAを導出する例です：

--- a/src/pages/ko/solana/compute-units-and-priority-fees.md
+++ b/src/pages/ko/solana/compute-units-and-priority-fees.md
@@ -4,7 +4,7 @@ metaTitle: Compute Units and Priority Fees | Solana Transaction Optimization
 description: Learn how to optimize Solana transactions with compute units and priority fees for better landing rates during network congestion.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 Master compute units and priority fees to ensure your transactions land reliably, even during network congestion. {% .lead %}
@@ -82,11 +82,16 @@ Priority Fee = Compute Units × Compute Unit Price (in micro-lamports)
 
 ```
 Compute Units: 200,000
-Price: 1,000 micro-lamports per CU
-Priority Fee: 200,000 × 1,000 = 200,000,000 micro-lamports
-            = 200,000 lamports
-            = 0.0002 SOL
+Price: 10,000 micro-lamports per CU
+Priority Fee: 200,000 × 10,000 = 2,000,000,000 micro-lamports
+            = 2,000 lamports          (1 lamport = 1,000,000 micro-lamports)
+            = 0.000002 SOL
+Total fee:    2,000 + 5,000 (base fee, 1 signature) = 7,000 lamports = 0.000007 SOL
 ```
+
+Try it: change the compute unit limit or the price and the fee updates live.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJmiyAvvBQBDSjskhKaKZSIAFAE5jrNAAQAzNGjsBeO8SQBbWgFdjdr4IIhh2AOt2tNbELgAUXnjElkhKADY6PkiWlKH0lnaMAKoAlHYA73aksLI11TUAOgg8SPqpjs5ukdZZItTtLgDUdgBGOhguTnEArHWydumZ2blo+cIA5gh6vpZoxY2NpPMZgtmdVTXyF3YJSSkLJzkAdAUAFjoIay6ULy5chawAIQ4ACU7HgEH4cnZxHZvi5UmgHJRHiANFp8IRICQVPwaPQmGxOLx+IJhKJxIYZJAlNAVPIQIpqaRNNo9AZIKBjKYiIAEwg83khLiCInmeASZjRsAxRAQ5CodAYWL+gJBJKEIjEEg5ICp9MZLJAun0hgQvi8wxWUDpF006JABCIxGguIVBPY3D48FJGop2qpNLpCigAA4DUb2ZyTGYsXyook0LBrolkmljlkoXkCoVUXaHViEDj5filf8gcC1WTNZS5EHIABOMNsk1mi2WKDMi6S6VY4gAFhdxZALHdxK96vJWukylpevbDa0hqb2q50ZAfJuKfu6eW+S32RzUvtmMQzqLipAyrLFZ9k51NYZVpqC-DzfNlsgHZtXaPjoAbAPz2HIlPQEccqz9adAwfGAn1ZY1lyjXkRjGCYOkzdZNkobYEyORYcgPbtEH7M8iEvVUx0rX0p0gWcYGZZ8l1AU03zbSApk7XNjy8OUjFdLFWEKAAZHgAElzEEgBNa8J2rSBrVrXspgY+DgG-PNDTAHi8XPAARESADURJ0jhpPA6joFDWtSHouCIzU49Ui0viQEEgBBVhzGYYEeAAZQAfR4Zg-J85hBNMqi7zY39aOi5S7M4x0pgAt1gPC28qQAdks6D2LiwwVyQuMensSZExCsL7KIHQnMHVydJ0tLZKmaLaxUOk8o5SqsVSQteMHNyPK83yAqC8rGogyAMt7Wi2sbFSupIDLkqxICPXG6i6xa6CVBsxcVKMRCY1hFodDaUq7HKuxYkODCth2YocwAXXgNAUE+LBIFwH8sSkaglFez4-L82UlGY1slGsNYXkoJRuKUHQ0kRMx4AwJBthiGUeNR9G0AACXeFAEUx0GWxWCG8Ch5GjB0SxPlXbjcRpun8YQQnzzhhGESRVFD3U37-retAgYLEmWPJynYdIJRhkR7mUbRywMfzXrscVvGCaJ5XRfByHocZ2m0HprSmcNlm2aIOGZa5iVeePfmAaFvy4Z2DBfFSGHdZhlBNPh2WqdVpWQAZ+WcbNzWg6ll23Y9im9aoE3V2942DcoMPzyT33rZ5wj7cF4XoG1snPaUDOraR-gA-PBBTxASu05lAuwaL2Oqf0FOiCT-XmY19OfbL7mEp+v6HaBjOo-d8XobSKW9xyP2K4VwPO5DtX66xMfMGjyfW4TohHK702e73me0yWefB51Ye878jfXYn4vqsz8uV6XzSF9Do-1598eY8pg-V2qv-NeIBH6c3LhfXOgNga9kLpYbe8Mpb939ovKuxFa4oOAQgGBTc4Ge3-lVZO3dWbh0fkg7O31L4CygY-H+8CeqpjwhgeeL9zyAJYcAmhm974t3wd1XqbciHmz4Qwh4TCs4aEehoIAA" embed=true /%}
 
 ### When to Use Priority Fees
 

--- a/src/pages/ko/solana/solana-transaction-fundamentals.md
+++ b/src/pages/ko/solana/solana-transaction-fundamentals.md
@@ -4,7 +4,7 @@ metaTitle: Solana Transaction Fundamentals | How Transactions Work
 description: Learn how Solana transactions work, including structure, signing, sending, and confirmation. Essential knowledge for building reliable applications.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 A comprehensive guide to understanding how Solana transactions work from structure to confirmation. {% .lead %}
@@ -57,6 +57,12 @@ A Solana transaction consists of several components:
 | **Recent Blockhash** | A recent block hash (valid for ~60-90 seconds) |
 | **Instructions** | The operations to perform |
 | **Account Keys** | All accounts involved in the transaction |
+
+### See a real transaction
+
+The flow below fetches a mainnet transaction with `getTransaction` and shows the raw structure from the diagram above: `signatures`, `message.header`, `accountKeys`, `recentBlockhash` and `instructions` (the example is a 2022 Token Metadata call). Paste any signature into the first node and press **Refresh** to inspect your own transaction.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0pAKyyAvvBQBDSjskhKaKZSIAFHRmMACHQmo2AtjrwIEaSjcoAnexh1iUXEbYQBzBD0AVx80GzdKJG8ACzieDgANHhtkdAA6Gx4AJQBBLgBlEsYeAElmLhsANRqOAHUbADNPYlSMeK8wPB0bMM8ePwQAoLEEAG4UuIApcvqbEMpUmx88MOSvPD6NuNidABs7SMSnakhQncuYzFhnTADRvNSddB9nwOIkKIISgAaTQ1Awz1ixDQQIAQqckMQANbJKzJZ5uaw+KLTcQYPIgDRafCESBGchUOgMMnpLL8QTCYISSDSOQKORaEC6fSGYymIgALwAVrCAI4ALR8HVU5QAbChxcCihhykVWgAOABGABkpABODo8NAAMQ6wJQRWgyUY0AA7gBFPAlWElShOe3lcq2jpSKQ+EoAJmoRWSkT1yBK9u1SAAqkKnOYAwAWTXmRbGgAirVIrXFCEa1EaYT15UJxJABCIHjMlPoRC4HB4rWYRWB9KEIhmhhkkHkIEUkD1mm0egMLMQnltSB8SKIrBKNS4Db4RNgJKIYApRipRGKZUq1TqXAA+s02u3GV3xz2k7I+wPb5zuWPgKv12SUFuaHWyRmauVzG1EoAE0L07cRuygAB2dV72UWVhy5UdeRMMwyTLNcK1JLkA34b9qRAP8AKA0D4AZcDmVZSAYLgyAAwQp9kPHPk0JADD3y5aA8J3X9-0AkCwKZSDqNg9kYEfEceWY1CiHYrCiGIXDawIlh2G4PgyI7ITrygUhSDvMSA3URipNAFiiEABMJQgRLx7BQGxNQRZFvDwJwGCJABdeA0BQUYsEgXB5LJKRqCUHzRmPY9KFIJQWKUbZdkoJRNyUcIHliJRTjQDoaxADAAR8aEiGi-h8piaEAAk7Ky4qYrihK9jwnQfFGVjNyalrPCqhAUBqskUrS6IMqynLCUwytgtC8K0Ei6slGrKcZ3inY9mSmKFunJFMuy3KysKgjq1KgrKuqg7PHmydNuWxKOtajcv2a1rut6giUo2paRrMcsJpAEKwt8mbjxS3x-ECJlFnyhBrtWz8lDcWgoiSz6jvK16tz2k6er68A6omKZwch6Hcv0TrWM-W6utOohYfhxHttG77sL+6bIoGmyiaUFAAzhhAEaRnaUf2+7Bcxl77tS9mGuJx7PGppSjBlyhnuxrmeb5+mvvGpmpoB1mYscxEkR4Vy0A5lBoDVunkfgDG0ZFtBlbRpQDeRY23KJimya4qhFcd6mLdp-mGY8jQgA" embed=true /%}
 
 ## Instructions
 

--- a/src/pages/ko/solana/understanding-pdas.md
+++ b/src/pages/ko/solana/understanding-pdas.md
@@ -4,7 +4,7 @@ title: Solana 프로그램 파생 주소(PDA) 이해하기
 metaTitle: Solana 프로그램 파생 주소 이해하기 | 가이드
 description: Solana 프로그램 파생 주소(PDA)와 그 사용 사례에 대해 학습합니다.
 created: '04-19-2024'
-updated: '04-19-2025'
+updated: '09-03-2026'
 keywords:
   - Program Derived Addresses
   - PDA
@@ -48,6 +48,18 @@ PDA는 프로그램 ID와 시드 값들의 조합을 사용하여 파생됩니�
 1. **프로그램 ID 선택**: PDA가 파생되는 프로그램의 공개 키입니다.
 2. **시드 선택**: 프로그램 ID와 함께 결합된 값을 기반으로 알고리즘적으로 PDA를 결정론적으로 생성할 하나 이상의 시드 값입니다.
 3. **PDA 계산**: `Pubkey::find_program_address` 함수를 사용하여 PDA를 파생합니다. 이 함수는 파생된 주소가 유효하고 일반적인(비PDA) 주소와 충돌할 수 없음을 보장합니다.
+
+### 직접 해보기: Token Metadata PDA
+
+모든 토큰의 메타데이터 계정은 Token Metadata 프로그램의 PDA이며, 세 개의 시드(문자열 `"metadata"`, 프로그램 ID `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`, mint)로부터 파생됩니다. 아래 플로우는 브라우저에서 `find_program_address`를 실행합니다. 세 번째 입력의 mint를 다른 mint로 바꾸면 메타데이터 주소가 갱신됩니다. 이것이 바로 `findMetadataPda(umi, { mint })`가 반환하는 값입니다.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJgAssgL7wUAQ0q7JISmimUirNAdoAbUwAIeSANZoE9ywb0H7ABQAiAIIAOgihGGhoKBj2ALz22MEgALZWut66SbD2lC5u9qle+rr2tABOSADmZbrJ9gTZyXgIlAC6oeVVNXXxua7uhenFpRXVtaGhHCgiOQAWaAXNlPYAFJSzeGUojhwAGjz2yOgAlPa6CNsA7vrEs3MLgxlnxMRIAK4tZygoZZgxb7RvGgAHSODYxPAxUy6YiUGzUeyXWb6ewAM2aKE8QwMvj0KzeTWywEWn00p1eyVobxMGGBIE02nwhEgxnIVDoDBZPD2fHggmEonERhkkHkIEUou0IAyRhMZiIj2K9MZIAIREoKn4NHoRG5+34-JEYgkkGkcgUUAAnFodErTcZTOYWYMAI4AIykUgAqmgti6VAAOYgAK1IACU3YEAOrOACaAEVktBqG6AF7Bt0ANl0AbdlAArKQA1JSFgGbAmeroFqObqeQahEahfaRWKJUWbdK7aA5U6QBxfMGAGJR775wJvVEugDK05daFYKhdXFIUlTKd0tEYAYA4mpLhwdzvnAAtS7UHj+SikCDlyss2hs4y1lkBQINgXG4VQNQqNtWzsZVNO9VWZaUn21TkQH8ABJadfAAGUCWMPybE0zUgTNM3-SANClICe0dIh8ykaAAwAaVoNRZjAFAkGSHhGAQRgykCBBqDUL1KFYLj8zKeMACEUAEzNaCkFRyNIL08DUfMoxdZUK1AogUE1dkdRZWD4KQlC+UbQV0JAEUsJw0h80A7sHXlFkVHzfNFPvEg1OfDSQBYdhuF5AR9K-FsoBMi1ICUUhSAsgxZSIlksSeGFXg+ZZ0h+P5VlRJAynuewvWnfxGBJShTnObZ1gWYhznEPBSpsew3QJWg6QZVp4CiSpMBwRypGoJRmrQAB9HqNSUXslDKPBKlmSglEfSbRm6GCUCUOxUXMeAMHeMpiCgjV+FWt51rQAAJQq7HVFRBsdYbRvGrVdDKFq+0fa7bqsQ6LmOh9SGmrpajmha0CW+klLVFkOq6lAWr668zrMC6xomqaIiiABiWRfv+la1o29Unx2vaXpQN7WShiaRthx67qIB6qBuu68YJ+HIhQZHUfMFUgaMzruoh06hpJ8bJo+hHGY+xblpAHHMZZLb0d2jbac27nzt50WDCe+6IOp56jqg+mkeFv6WcBsCQc5-roCJmG+Z1xnTpF7aMc26tpdxrWq3NpWyasCn1dVuWvaUQXEZt-WAfajmwd6nqpsBXQLYmlAPuaKkJttp2JYEbH7d997Jr0WOPb7eP86z8ClET6lmZD5TgbD8HI4+mrKVjpRVNLhAk4r1PtYzmWDpd7OG9oPOqdVlTnJVmm++lU6y+T4PNFaTQgA" embed=true /%}
+
+```javascript
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata'
+
+const [metadataPda, bump] = findMetadataPda(umi, { mint })
+```
 
 ## Rust 예제
 다음은 Rust로 작성된 Solana 프로그램에서 PDA를 파생하는 예제입니다:

--- a/src/pages/zh/solana/compute-units-and-priority-fees.md
+++ b/src/pages/zh/solana/compute-units-and-priority-fees.md
@@ -4,7 +4,7 @@ metaTitle: Compute Units and Priority Fees | Solana Transaction Optimization
 description: Learn how to optimize Solana transactions with compute units and priority fees for better landing rates during network congestion.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 Master compute units and priority fees to ensure your transactions land reliably, even during network congestion. {% .lead %}
@@ -82,11 +82,16 @@ Priority Fee = Compute Units × Compute Unit Price (in micro-lamports)
 
 ```
 Compute Units: 200,000
-Price: 1,000 micro-lamports per CU
-Priority Fee: 200,000 × 1,000 = 200,000,000 micro-lamports
-            = 200,000 lamports
-            = 0.0002 SOL
+Price: 10,000 micro-lamports per CU
+Priority Fee: 200,000 × 10,000 = 2,000,000,000 micro-lamports
+            = 2,000 lamports          (1 lamport = 1,000,000 micro-lamports)
+            = 0.000002 SOL
+Total fee:    2,000 + 5,000 (base fee, 1 signature) = 7,000 lamports = 0.000007 SOL
 ```
+
+Try it: change the compute unit limit or the price and the fee updates live.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJmiyAvvBQBDSjskhKaKZSIAFAE5jrNAAQAzNGjsBeO8SQBbWgFdjdr4IIhh2AOt2tNbELgAUXnjElkhKADY6PkiWlKH0lnaMAKoAlHYA73aksLI11TUAOgg8SPqpjs5ukdZZItTtLgDUdgBGOhguTnEArHWydumZ2blo+cIA5gh6vpZoxY2NpPMZgtmdVTXyF3YJSSkLJzkAdAUAFjoIay6ULy5chawAIQ4ACU7HgEH4cnZxHZvi5UmgHJRHiANFp8IRICQVPwaPQmGxOLx+IJhKJxIYZJAlNAVPIQIpqaRNNo9AZIKBjKYiIAEwg83khLiCInmeASZjRsAxRAQ5CodAYWL+gJBJKEIjEEg5ICp9MZLJAun0hgQvi8wxWUDpF006JABCIxGguIVBPY3D48FJGop2qpNLpCigAA4DUb2ZyTGYsXyook0LBrolkmljlkoXkCoVUXaHViEDj5filf8gcC1WTNZS5EHIABOMNsk1mi2WKDMi6S6VY4gAFhdxZALHdxK96vJWukylpevbDa0hqb2q50ZAfJuKfu6eW+S32RzUvtmMQzqLipAyrLFZ9k51NYZVpqC-DzfNlsgHZtXaPjoAbAPz2HIlPQEccqz9adAwfGAn1ZY1lyjXkRjGCYOkzdZNkobYEyORYcgPbtEH7M8iEvVUx0rX0p0gWcYGZZ8l1AU03zbSApk7XNjy8OUjFdLFWEKAAZHgAElzEEgBNa8J2rSBrVrXspgY+DgG-PNDTAHi8XPAARESADURJ0jhpPA6joFDWtSHouCIzU49Ui0viQEEgBBVhzGYYEeAAZQAfR4Zg-J85hBNMqi7zY39aOi5S7M4x0pgAt1gPC28qQAdks6D2LiwwVyQuMensSZExCsL7KIHQnMHVydJ0tLZKmaLaxUOk8o5SqsVSQteMHNyPK83yAqC8rGogyAMt7Wi2sbFSupIDLkqxICPXG6i6xa6CVBsxcVKMRCY1hFodDaUq7HKuxYkODCth2YocwAXXgNAUE+LBIFwH8sSkaglFez4-L82UlGY1slGsNYXkoJRuKUHQ0kRMx4AwJBthiGUeNR9G0AACXeFAEUx0GWxWCG8Ch5GjB0SxPlXbjcRpun8YQQnzzhhGESRVFD3U37-retAgYLEmWPJynYdIJRhkR7mUbRywMfzXrscVvGCaJ5XRfByHocZ2m0HprSmcNlm2aIOGZa5iVeePfmAaFvy4Z2DBfFSGHdZhlBNPh2WqdVpWQAZ+WcbNzWg6ll23Y9im9aoE3V2942DcoMPzyT33rZ5wj7cF4XoG1snPaUDOraR-gA-PBBTxASu05lAuwaL2Oqf0FOiCT-XmY19OfbL7mEp+v6HaBjOo-d8XobSKW9xyP2K4VwPO5DtX66xMfMGjyfW4TohHK702e73me0yWefB51Ye878jfXYn4vqsz8uV6XzSF9Do-1598eY8pg-V2qv-NeIBH6c3LhfXOgNga9kLpYbe8Mpb939ovKuxFa4oOAQgGBTc4Ge3-lVZO3dWbh0fkg7O31L4CygY-H+8CeqpjwhgeeL9zyAJYcAmhm974t3wd1XqbciHmz4Qwh4TCs4aEehoIAA" embed=true /%}
 
 ### When to Use Priority Fees
 

--- a/src/pages/zh/solana/solana-transaction-fundamentals.md
+++ b/src/pages/zh/solana/solana-transaction-fundamentals.md
@@ -4,7 +4,7 @@ metaTitle: Solana Transaction Fundamentals | How Transactions Work
 description: Learn how Solana transactions work, including structure, signing, sending, and confirmation. Essential knowledge for building reliable applications.
 # remember to update dates also in /components/products/guides/index.js
 created: '02-04-2026'
-updated: null
+updated: '09-03-2026'
 ---
 
 A comprehensive guide to understanding how Solana transactions work from structure to confirmation. {% .lead %}
@@ -57,6 +57,12 @@ A Solana transaction consists of several components:
 | **Recent Blockhash** | A recent block hash (valid for ~60-90 seconds) |
 | **Instructions** | The operations to perform |
 | **Account Keys** | All accounts involved in the transaction |
+
+### See a real transaction
+
+The flow below fetches a mainnet transaction with `getTransaction` and shows the raw structure from the diagram above: `signatures`, `message.header`, `accountKeys`, `recentBlockhash` and `instructions` (the example is a 2022 Token Metadata call). Paste any signature into the first node and press **Refresh** to inspect your own transaction.
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0pAKyyAvvBQBDSjskhKaKZSIAFHRmMACHQmo2AtjrwIEaSjcoAnexh1iUXEbYQBzBD0AVx80GzdKJG8ACzieDgANHhtkdAA6Gx4AJQBBLgBlEsYeAElmLhsANRqOAHUbADNPYlSMeK8wPB0bMM8ePwQAoLEEAG4UuIApcvqbEMpUmx88MOSvPD6NuNidABs7SMSnakhQncuYzFhnTADRvNSddB9nwOIkKIISgAaTQ1Awz1ixDQQIAQqckMQANbJKzJZ5uaw+KLTcQYPIgDRafCESBGchUOgMMnpLL8QTCYISSDSOQKORaEC6fSGYymIgALwAVrCAI4ALR8HVU5QAbChxcCihhykVWgAOABGABkpABODo8NAAMQ6wJQRWgyUY0AA7gBFPAlWElShOe3lcq2jpSKQ+EoAJmoRWSkT1yBK9u1SAAqkKnOYAwAWTXmRbGgAirVIrXFCEa1EaYT15UJxJABCIHjMlPoRC4HB4rWYRWB9KEIhmhhkkHkIEUkD1mm0egMLMQnltSB8SKIrBKNS4Db4RNgJKIYApRipRGKZUq1TqXAA+s02u3GV3xz2k7I+wPb5zuWPgKv12SUFuaHWyRmauVzG1EoAE0L07cRuygAB2dV72UWVhy5UdeRMMwyTLNcK1JLkA34b9qRAP8AKA0D4AZcDmVZSAYLgyAAwQp9kPHPk0JADD3y5aA8J3X9-0AkCwKZSDqNg9kYEfEceWY1CiHYrCiGIXDawIlh2G4PgyI7ITrygUhSDvMSA3URipNAFiiEABMJQgRLx7BQGxNQRZFvDwJwGCJABdeA0BQUYsEgXB5LJKRqCUHzRmPY9KFIJQWKUbZdkoJRNyUcIHliJRTjQDoaxADAAR8aEiGi-h8piaEAAk7Ky4qYrihK9jwnQfFGVjNyalrPCqhAUBqskUrS6IMqynLCUwytgtC8K0Ei6slGrKcZ3inY9mSmKFunJFMuy3KysKgjq1KgrKuqg7PHmydNuWxKOtajcv2a1rut6giUo2paRrMcsJpAEKwt8mbjxS3x-ECJlFnyhBrtWz8lDcWgoiSz6jvK16tz2k6er68A6omKZwch6Hcv0TrWM-W6utOohYfhxHttG77sL+6bIoGmyiaUFAAzhhAEaRnaUf2+7Bcxl77tS9mGuJx7PGppSjBlyhnuxrmeb5+mvvGpmpoB1mYscxEkR4Vy0A5lBoDVunkfgDG0ZFtBlbRpQDeRY23KJimya4qhFcd6mLdp-mGY8jQgA" embed=true /%}
 
 ## Instructions
 

--- a/src/pages/zh/solana/understanding-pdas.md
+++ b/src/pages/zh/solana/understanding-pdas.md
@@ -4,7 +4,7 @@ title: 理解 Solana 程序派生地址（PDA）
 metaTitle: 理解 Solana 程序派生地址 | 指南
 description: 了解 Solana 程序派生地址（PDA）及其用例。
 created: '04-19-2024'
-updated: '04-19-2025'
+updated: '09-03-2026'
 keywords:
   - Program Derived Addresses
   - PDA
@@ -48,6 +48,18 @@ PDA 是使用程序 ID 和一组种子值的组合派生的。派生过程涉及
 1. **选择程序 ID**：正在派生 PDA 的程序的公钥。
 2. **选择种子**：一个或多个种子值，与程序 ID 一起，将根据组合值通过算法确定性地生成 PDA。
 3. **计算 PDA**：使用 `Pubkey::find_program_address` 函数派生 PDA。此函数确保派生的地址有效且不会与任何常规（非 PDA）地址冲突。
+
+### 动手试试：Token Metadata PDA
+
+每个代币的元数据账户都是 Token Metadata 程序的 PDA，由三个种子派生：字符串 `"metadata"`、程序 ID `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s` 和 mint。下面的流程在浏览器中执行 `find_program_address`。把第三个输入中的 mint 换成任意 mint，元数据地址会随之更新——这正是 `findMetadataPda(umi, { mint })` 的返回值。
+
+{% video src="https://plgrnd.io/embed?theme=dark&ref=metaplex-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJgAssgL7wUAQ0q7JISmimUirNAdoAbUwAIeSANZoE9ywb0H7ABQAiAIIAOgihGGhoKBj2ALz22MEgALZWut66SbD2lC5u9qle+rr2tABOSADmZbrJ9gTZyXgIlAC6oeVVNXXxua7uhenFpRXVtaGhHCgiOQAWaAXNlPYAFJSzeGUojhwAGjz2yOgAlPa6CNsA7vrEs3MLgxlnxMRIAK4tZygoZZgxb7RvGgAHSODYxPAxUy6YiUGzUeyXWb6ewAM2aKE8QwMvj0KzeTWywEWn00p1eyVobxMGGBIE02nwhEgxnIVDoDBZPD2fHggmEonERhkkHkIEUou0IAyRhMZiIj2K9MZIAIREoKn4NHoRG5+34-JEYgkkGkcgUUAAnFodErTcZTOYWYMAI4AIykUgAqmgti6VAAOYgAK1IACU3YEAOrOACaAEVktBqG6AF7Bt0ANl0AbdlAArKQA1JSFgGbAmeroFqObqeQahEahfaRWKJUWbdK7aA5U6QBxfMGAGJR775wJvVEugDK05daFYKhdXFIUlTKd0tEYAYA4mpLhwdzvnAAtS7UHj+SikCDlyss2hs4y1lkBQINgXG4VQNQqNtWzsZVNO9VWZaUn21TkQH8ABJadfAAGUCWMPybE0zUgTNM3-SANClICe0dIh8ykaAAwAaVoNRZjAFAkGSHhGAQRgykCBBqDUL1KFYLj8zKeMACEUAEzNaCkFRyNIL08DUfMoxdZUK1AogUE1dkdRZWD4KQlC+UbQV0JAEUsJw0h80A7sHXlFkVHzfNFPvEg1OfDSQBYdhuF5AR9K-FsoBMi1ICUUhSAsgxZSIlksSeGFXg+ZZ0h+P5VlRJAynuewvWnfxGBJShTnObZ1gWYhznEPBSpsew3QJWg6QZVp4CiSpMBwRypGoJRmrQAB9HqNSUXslDKPBKlmSglEfSbRm6GCUCUOxUXMeAMHeMpiCgjV+FWt51rQAAJQq7HVFRBsdYbRvGrVdDKFq+0fa7bqsQ6LmOh9SGmrpajmha0CW+klLVFkOq6lAWr668zrMC6xomqaIiiABiWRfv+la1o29Unx2vaXpQN7WShiaRthx67qIB6qBuu68YJ+HIhQZHUfMFUgaMzruoh06hpJ8bJo+hHGY+xblpAHHMZZLb0d2jbac27nzt50WDCe+6IOp56jqg+mkeFv6WcBsCQc5-roCJmG+Z1xnTpF7aMc26tpdxrWq3NpWyasCn1dVuWvaUQXEZt-WAfajmwd6nqpsBXQLYmlAPuaKkJttp2JYEbH7d997Jr0WOPb7eP86z8ClET6lmZD5TgbD8HI4+mrKVjpRVNLhAk4r1PtYzmWDpd7OG9oPOqdVlTnJVmm++lU6y+T4PNFaTQgA" embed=true /%}
+
+```javascript
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata'
+
+const [metadataPda, bump] = findMetadataPda(umi, { mint })
+```
 
 ## Rust 示例
 以下是在用 Rust 编写的 Solana 程序中派生 PDA 的示例：


### PR DESCRIPTION
## What

Proposal: give three Solana Basics pages a small interactive example right where the concept is explained, so readers can try it instead of only reading about it. The examples are flows from [PLGRND](https://plgrnd.io), an open-source visual playground for Solana (MIT, source: https://github.com/RedDuckTeam/PLGRND), embedded with the existing `{% video … embed=true /%}` Markdoc tag. No new components, no new dependencies.

- **Understanding PDAs** — derives the Token Metadata PDA for a mint (`"metadata"` + program id + mint), the exact computation behind `findMetadataPda`. Paste any mint and the metadata address and bump update.
- **Compute Units and Priority Fees** — a live fee calculator under "Example Calculation": CU limit × price ÷ 1,000,000 plus the 5,000-lamport base fee.
- **Solana Transaction Fundamentals** — a real mainnet transaction fetched with `getTransaction`, shown next to the "Key Components" table: signatures, header, account keys, recent blockhash, instructions. Paste any signature to inspect it.

## Also fixed

"Example Calculation" on the priority fees page converted 200,000,000 micro-lamports to 200,000 lamports; the correct value is 200 lamports (1 lamport = 1,000,000 micro-lamports). The example now uses 10,000 micro-lamports per CU → 2,000 lamports = 0.000002 SOL, and adds the 0 lamports), matching the "Fee Calculation"section above it.                                                                                                    
## Details

- Same tag and URL in `en`, `ja`, `ko`, `zh`. The fee and transaction pages are English in all four locales already, so only the tag was added there; the new PDA `ja`/`ko`/`zh` (a draft translation, happy to take corrections).
- `updated` bumped in the frontmatter and in `src/components/products/guides/index.js`.

Two things I'd defer to you on: `Video.jsx` gives the iframe no `title` or `sandbox`, and adds a `Powered by PLGRND` badge that is part of the embed. If you'd prefer a dedicated `{% plgrnd %}` tag with `sandbox`, `title` and `loading="lazy"`, or would rather drop any of the three flows, I'll adjust.